### PR TITLE
Integrate Mergify

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,27 @@
+# If labeled: "BACKPORT", mergify will cherry-pick PR into all maintained branches
+pull_request_rules:
+  - name: backport to maintained branches
+    conditions:
+      - base~=^(main|release/v4|release/v5|release/v6)$
+      - label=BACKPORT
+    actions:
+      backport:
+        branches:
+          - main
+          - release/v4
+          - release/v5
+          - release/v6
+        assignees: 
+            - "{{ author }}"
+        labels:
+          - automerge
+          - backport
+        title: "`[BP: {{ destination_branch }} <- #{{ number }}]` {{ title }}"
+
+  - name: automerge backported PR's for maintained branches
+    conditions:
+      - label=automerge
+      - base~=^(release/v4|release/v5|release/v6)$
+    actions:
+      merge:
+        method: squash

--- a/README.md
+++ b/README.md
@@ -55,6 +55,14 @@ If you'd like to include software in this repo, please see [contributing](../ibc
 
 An [example IBC app](./examples/hello-world/)
 
+## Maintained Branches
+
+|                          **Branch Name**                         | **IBC-Go** |
+|:----------------------------------------------------------------:|:----------:|
+|            [main](https://github.com/cosmos/ibc-apps)            |     v7     |
+| [release/v6](https://github.com/cosmos/ibc-apps/tree/release/v6) |     v6     |
+| [release/v5](https://github.com/cosmos/ibc-apps/tree/release/v5) |     v5     |
+| [release/v4](https://github.com/cosmos/ibc-apps/tree/release/v4) |     v4     |
 
 ## List of Apps
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,9 +4,9 @@ Documentation for IBC apps
 
 ## Backporting to Maintained Branches
 
-Because chains are on different versions of IBC-Go, we strive to have app compatibility across older versions of IBC-Go.
+Because chains are on different versions of ibc-go, we strive to have app compatibility across older versions of ibc-go.
 
-To do this, we maintain several branches each targeting a different version of IBC-Go. You can view our maintained branches [here](https://github.com/cosmos/ibc-apps/tree/main#maintained-branches)
+To do this, we maintain several branches each targeting a different version of ibc-go. You can view our maintained branches [here](https://github.com/cosmos/ibc-apps/tree/main#maintained-branches)
 
 
 [`Mergify`](https://mergify.com/) has been integrated into this repo to help keep these branches in sync. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,21 @@
 # Docs
 
 Documentation for IBC apps
+
+## Backporting to Maintained Branches
+
+Because chains are on different versions of IBC-Go, we strive to have app compatibility across older versions of IBC-Go.
+
+To do this, we maintain several branches each targeting a different version of IBC-Go. You can view our maintained branches [here](https://github.com/cosmos/ibc-apps/tree/main#maintained-branches)
+
+
+[`Mergify`](https://mergify.com/) has been integrated into this repo to help keep these branches in sync. 
+
+
+Please add the `BACKPORT` label to your PR if it should be cherry-picked into our maintained branches.
+
+
+Note:
+
+You can target any of the maintained branches. For example, if you target branch `release/v5` and add the label, the merge commit will be cherry-picked into `main` and any other maintained branch.
+


### PR DESCRIPTION
This PR Integrates Mergify to help keep our maintained branches up to date.

If a PR has the `BACKPORT` label, after it is merged, Mergify will automatically create PR's cherry-picking the merge commit into each of our maintained branches. 


Note: It doesn't matter what branch you target. If you target `release/v5`, It will be backported into `main`, `release/v4`, and `release/v6`

Closes: #7 