### PR TITLE
ci: add golangci-lint config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,78 @@
+run:
+  tests: true
+  #   # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 5m
+
+linters:
+  disable-all: true
+  enable:
+    - dogsled
+    - exportloopref
+    - errcheck
+    - gci
+    - goconst
+    - gocritic
+    - gofumpt
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - nakedret
+    - staticcheck
+    - thelper
+    - stylecheck
+    - revive
+    - typecheck
+    - unconvert
+    - unused
+    - misspell
+
+issues:
+  exclude-rules:
+    - text: 'unused-parameter'
+      linters:
+        - revive
+    - text: 'SA1019:'
+      linters:
+        - staticcheck
+    - text: 'Use of weak random number generator'
+      linters:
+        - gosec
+    - text: 'ST1003:'
+      linters:
+        - stylecheck
+    # FIXME: Disabled until golangci-lint updates stylecheck with this fix:
+    # https://github.com/dominikh/go-tools/issues/389
+    - text: 'ST1016:'
+      linters:
+        - stylecheck
+  max-issues-per-linter: 10000
+  max-same-issues: 10000
+
+linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - blank # blank imports
+      - dot # dot imports
+      - prefix(cosmossdk.io)
+      - prefix(github.com/cosmos/cosmos-sdk)
+      - prefix(github.com/cometbft/cometbft)
+      - prefix(github.com/cosmos/ibc-go)
+    custom-order: true
+  dogsled:
+    max-blank-identifiers: 3
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  nolintlint:
+    allow-unused: false
+    allow-leading-space: true
+    require-explanation: false
+    require-specific: false
+  revive:
+    rules:
+      - name: if-return
+        disabled: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,6 +51,17 @@ issues:
   max-same-issues: 10000
 
 linters-settings:
+  gci:
+    sections:
+      - standard # Standard section: captures all standard packages.
+      - default # Default section: contains all imports that could not be matched to another section type.
+      - blank # blank imports
+      - dot # dot imports
+      - prefix(cosmossdk.io)
+      - prefix(github.com/cosmos/cosmos-sdk)
+      - prefix(github.com/cometbft/cometbft)
+      - prefix(github.com/cosmos/ibc-go)
+    custom-order: true
   dogsled:
     max-blank-identifiers: 3
   maligned:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -51,17 +51,6 @@ issues:
   max-same-issues: 10000
 
 linters-settings:
-  gci:
-    sections:
-      - standard # Standard section: captures all standard packages.
-      - default # Default section: contains all imports that could not be matched to another section type.
-      - blank # blank imports
-      - dot # dot imports
-      - prefix(cosmossdk.io)
-      - prefix(github.com/cosmos/cosmos-sdk)
-      - prefix(github.com/cometbft/cometbft)
-      - prefix(github.com/cosmos/ibc-go)
-    custom-order: true
   dogsled:
     max-blank-identifiers: 3
   maligned:

--- a/modules/async-icq/ibc_module.go
+++ b/modules/async-icq/ibc_module.go
@@ -3,12 +3,14 @@ package icq
 import (
 	"strings"
 
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
 	"cosmossdk.io/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"

--- a/modules/async-icq/ibc_module_test.go
+++ b/modules/async-icq/ibc_module_test.go
@@ -3,20 +3,23 @@ package icq_test
 import (
 	"testing"
 
-	abcitypes "github.com/cometbft/cometbft/abci/types"
-	tmprotostate "github.com/cometbft/cometbft/proto/tendermint/state"
-	tmstate "github.com/cometbft/cometbft/state"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	"github.com/cosmos/gogoproto/proto"
 	icq "github.com/cosmos/ibc-apps/modules/async-icq/v7"
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/testing/simapp"
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	"github.com/stretchr/testify/suite"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
+	tmprotostate "github.com/cometbft/cometbft/proto/tendermint/state"
+	tmstate "github.com/cometbft/cometbft/state"
+
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
-	"github.com/stretchr/testify/suite"
 )
 
 var (

--- a/modules/async-icq/keeper/events.go
+++ b/modules/async-icq/keeper/events.go
@@ -1,9 +1,10 @@
 package keeper
 
 import (
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
 	"github.com/cosmos/ibc-go/v7/modules/core/exported"
 )
 

--- a/modules/async-icq/keeper/genesis.go
+++ b/modules/async-icq/keeper/genesis.go
@@ -3,9 +3,9 @@ package keeper
 import (
 	"fmt"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // InitGenesis initializes the icq state and binds to PortID.

--- a/modules/async-icq/keeper/grpc_query.go
+++ b/modules/async-icq/keeper/grpc_query.go
@@ -3,9 +3,9 @@ package keeper
 import (
 	"context"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 var _ types.QueryServer = Keeper{}

--- a/modules/async-icq/keeper/grpc_query_test.go
+++ b/modules/async-icq/keeper/grpc_query_test.go
@@ -1,10 +1,10 @@
 package keeper_test
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/testing/simapp"
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 func (suite *KeeperTestSuite) TestQueryParams() {

--- a/modules/async-icq/keeper/keeper.go
+++ b/modules/async-icq/keeper/keeper.go
@@ -3,17 +3,19 @@ package keeper
 import (
 	"fmt"
 
-	"github.com/cometbft/cometbft/libs/log"
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
 	"github.com/cosmos/cosmos-sdk/codec"
 	storetypes "github.com/cosmos/cosmos-sdk/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitykeeper "github.com/cosmos/cosmos-sdk/x/capability/keeper"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
-	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	"github.com/cometbft/cometbft/libs/log"
+
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
+	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 )
 
 // Keeper defines the IBC interchain query host keeper

--- a/modules/async-icq/keeper/keeper_test.go
+++ b/modules/async-icq/keeper/keeper_test.go
@@ -3,10 +3,10 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/suite"
-
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/testing/simapp"
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	"github.com/stretchr/testify/suite"
+
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 )

--- a/modules/async-icq/keeper/params.go
+++ b/modules/async-icq/keeper/params.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // IsHostEnabled retrieves the host enabled boolean from the paramstore.

--- a/modules/async-icq/keeper/relay.go
+++ b/modules/async-icq/keeper/relay.go
@@ -1,13 +1,15 @@
 package keeper
 
 import (
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
 	"cosmossdk.io/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
 	abci "github.com/cometbft/cometbft/abci/types"
 
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 )
 

--- a/modules/async-icq/keeper/relay_test.go
+++ b/modules/async-icq/keeper/relay_test.go
@@ -1,13 +1,14 @@
 package keeper_test
 
 import (
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/testing/simapp"
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+
 	"github.com/cosmos/cosmos-sdk/types/query"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 
 	abcitypes "github.com/cometbft/cometbft/abci/types"
 
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/testing/simapp"
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
 	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"

--- a/modules/async-icq/module.go
+++ b/modules/async-icq/module.go
@@ -5,18 +5,20 @@ import (
 	"encoding/json"
 	"fmt"
 
-	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	"github.com/gorilla/mux"
+	"github.com/grpc-ecosystem/grpc-gateway/runtime"
+	"github.com/spf13/cobra"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/cosmos-sdk/types/module"
-	"github.com/gorilla/mux"
-	"github.com/grpc-ecosystem/grpc-gateway/runtime"
-	"github.com/spf13/cobra"
 
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	abci "github.com/cometbft/cometbft/abci/types"
+
 	porttypes "github.com/cosmos/ibc-go/v7/modules/core/05-port/types"
 )
 

--- a/modules/async-icq/testing/simapp/ante_handler.go
+++ b/modules/async-icq/testing/simapp/ante_handler.go
@@ -2,6 +2,7 @@ package simapp
 
 import (
 	"cosmossdk.io/errors"
+
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"github.com/cosmos/cosmos-sdk/x/auth/ante"

--- a/modules/async-icq/testing/simapp/app.go
+++ b/modules/async-icq/testing/simapp/app.go
@@ -7,18 +7,27 @@ import (
 	"os"
 	"path/filepath"
 
+	icq "github.com/cosmos/ibc-apps/modules/async-icq/v7"
+	icqkeeper "github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
+	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	"github.com/gorilla/mux"
+	"github.com/rakyll/statik/fs"
+	"github.com/spf13/cast"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/cosmos/cosmos-sdk/client/docs/statik" // this is used for serving docs
+
 	autocliv1 "cosmossdk.io/api/cosmos/autocli/v1"
 	reflectionv1 "cosmossdk.io/api/cosmos/reflection/v1"
-	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
 
 	"github.com/cosmos/cosmos-sdk/baseapp"
 	"github.com/cosmos/cosmos-sdk/client"
-	_ "github.com/cosmos/cosmos-sdk/client/docs/statik" // this is used for serving docs
 	nodeservice "github.com/cosmos/cosmos-sdk/client/grpc/node"
 	"github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	"github.com/cosmos/cosmos-sdk/codec"
 	"github.com/cosmos/cosmos-sdk/codec/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
+	runtimeservices "github.com/cosmos/cosmos-sdk/runtime/services"
 	"github.com/cosmos/cosmos-sdk/server/api"
 	"github.com/cosmos/cosmos-sdk/server/config"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
@@ -89,6 +98,11 @@ import (
 	upgradekeeper "github.com/cosmos/cosmos-sdk/x/upgrade/keeper"
 	upgradetypes "github.com/cosmos/cosmos-sdk/x/upgrade/types"
 
+	dbm "github.com/cometbft/cometbft-db"
+	abci "github.com/cometbft/cometbft/abci/types"
+	"github.com/cometbft/cometbft/libs/log"
+	tmos "github.com/cometbft/cometbft/libs/os"
+
 	ibc "github.com/cosmos/ibc-go/v7/modules/core"
 	ibcclient "github.com/cosmos/ibc-go/v7/modules/core/02-client"
 	ibcclientclient "github.com/cosmos/ibc-go/v7/modules/core/02-client/client"
@@ -101,19 +115,6 @@ import (
 	"github.com/cosmos/ibc-go/v7/testing/simapp"
 	simappparams "github.com/cosmos/ibc-go/v7/testing/simapp/params"
 	ibctestingtypes "github.com/cosmos/ibc-go/v7/testing/types"
-
-	"github.com/gorilla/mux"
-	"github.com/rakyll/statik/fs"
-	"github.com/spf13/cast"
-
-	dbm "github.com/cometbft/cometbft-db"
-	abci "github.com/cometbft/cometbft/abci/types"
-	"github.com/cometbft/cometbft/libs/log"
-	tmos "github.com/cometbft/cometbft/libs/os"
-	icq "github.com/cosmos/ibc-apps/modules/async-icq/v7"
-	icqkeeper "github.com/cosmos/ibc-apps/modules/async-icq/v7/keeper"
-	icqtypes "github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
-	"github.com/stretchr/testify/require"
 )
 
 const appName = "SimApp"

--- a/modules/async-icq/testing/simapp/export.go
+++ b/modules/async-icq/testing/simapp/export.go
@@ -4,12 +4,13 @@ import (
 	"encoding/json"
 	"log"
 
-	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	servertypes "github.com/cosmos/cosmos-sdk/server/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	slashingtypes "github.com/cosmos/cosmos-sdk/x/slashing/types"
 	"github.com/cosmos/cosmos-sdk/x/staking"
 	stakingtypes "github.com/cosmos/cosmos-sdk/x/staking/types"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
 )
 
 // ExportAppStateAndValidators exports the state of the application for a genesis

--- a/modules/async-icq/types/codec.go
+++ b/modules/async-icq/types/codec.go
@@ -1,9 +1,10 @@
 package types
 
 import (
-	abcitypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/cosmos/cosmos-sdk/codec"
 	codectypes "github.com/cosmos/cosmos-sdk/codec/types"
+
+	abcitypes "github.com/cometbft/cometbft/abci/types"
 )
 
 // ModuleCdc references the global interchain queries module codec. Note, the codec

--- a/modules/async-icq/types/expected_keepers.go
+++ b/modules/async-icq/types/expected_keepers.go
@@ -3,8 +3,8 @@ package types
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	capabilitytypes "github.com/cosmos/cosmos-sdk/x/capability/types"
-	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 
+	clienttypes "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	channeltypes "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	ibcexported "github.com/cosmos/ibc-go/v7/modules/core/exported"
 )

--- a/modules/async-icq/types/genesis_test.go
+++ b/modules/async-icq/types/genesis_test.go
@@ -3,9 +3,9 @@ package types_test
 import (
 	"testing"
 
+	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
 	ibctesting "github.com/cosmos/ibc-go/v7/testing"
 )
 

--- a/modules/async-icq/types/params_test.go
+++ b/modules/async-icq/types/params_test.go
@@ -3,9 +3,8 @@ package types_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	"github.com/cosmos/ibc-apps/modules/async-icq/v7/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidateParams(t *testing.T) {


### PR DESCRIPTION
This PR adds the actual golangci-lint config file to the top level of the repo, this should ensure that the linter is actually running in CI. 

Additionally, I have fixed the few linter errors in `async-icq` that were being thrown.