### PR TITLE
set fail-fast to false for linting CI

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix: ${{ fromJson(needs.resolve-modules.outputs.matrix) }}
+      fail-fast: false
     steps:
       - uses: actions/checkout@v3
       - name: golangci-lint


### PR DESCRIPTION
Currently, in our concurrent linter CI, if one linter test fails, any other linter related test does not run or gets cancelled. 

This PR should fix this. Thus allowing all modules to get linted even if one module throws a linting error. 

