### PR TITLE
docs: create an integration guide for the pfm

### DIFF
--- a/middleware/packet-forward-middleware/docs/integration.md
+++ b/middleware/packet-forward-middleware/docs/integration.md
@@ -1,0 +1,156 @@
+# Integration
+This document provides instructions on integrating and configuring the Packet Forward Middleware (PFM) within your
+existing chain implementation. This document is _NOT_ a guide on developing with the Cosmos SDK or ibc-go and makes
+the assumption that you have some existing codebase for your chain with IBC already enabled.
+
+## Example integration of the Packet Forward Middleware
+
+```go
+// app.go
+
+// Import the packet forward middleware
+import (
+    packetforward "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router"
+    packetforwardkeeper "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/keeper"
+    packetforwardtypes "github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/types"
+)
+
+...
+
+// Register the AppModule for the packet forward middleware module
+ModuleBasics = module.NewBasicManager(
+    ...
+    packetforward.AppModuleBasic{},
+    ...
+)
+
+...
+
+// Add packet forward middleware Keeper
+type App struct {
+	...
+	PacketForwardKeeper *packetforwardkeeper.Keeper
+	...
+}
+
+...
+
+// Create store keys 
+keys := sdk.NewKVStoreKeys(
+    ...
+    packetforwardtypes.StoreKey,
+    ...
+)
+
+...
+
+// Initialize the packet forward middleware Keeper
+// It's important to note that the PFM Keeper must be initialized before the Transfer Keeper
+app.PacketForwardKeeper = packetforwardkeeper.NewKeeper(
+    appCodec,
+    keys[packetforwardtypes.StoreKey],
+    app.GetSubspace(packetforwardtypes.ModuleName),
+    app.TransferKeeper, // will be zero-value here, reference is set later on with SetTransferKeeper.
+    app.IBCKeeper.ChannelKeeper,
+    appKeepers.DistrKeeper,
+    app.BankKeeper,
+    app.IBCKeeper.ChannelKeeper,
+)
+
+// Initialize the transfer module Keeper
+app.TransferKeeper = ibctransferkeeper.NewKeeper(
+    appCodec,
+    keys[ibctransfertypes.StoreKey],
+    app.GetSubspace(ibctransfertypes.ModuleName),
+    app.PacketForwardKeeper,
+    app.IBCKeeper.ChannelKeeper,
+    &app.IBCKeeper.PortKeeper,
+    app.AccountKeeper,
+    app.BankKeeper,
+    scopedTransferKeeper,
+)
+
+app.PacketForwardKeeper.SetTransferKeeper(app.TransferKeeper)
+
+// See the section below for configuring an application stack with the packet forward middleware 
+
+...
+
+// Register packet forward middleware AppModule
+app.moduleManager = module.NewManager(
+    ...
+    packetforward.NewAppModule(app.PacketForwardKeeper),
+)
+
+...
+
+// Add packet forward middleware to begin blocker logic
+app.moduleManager.SetOrderBeginBlockers(
+    ...
+    packetforwardtypes.ModuleName,
+    ...
+)
+
+// Add packet forward middleware to end blocker logic
+app.moduleManager.SetOrderEndBlockers(
+    ...
+    packetforwardtypes.ModuleName,
+    ...
+)
+
+// Add packet forward middleware to init genesis logic
+app.moduleManager.SetOrderInitGenesis(
+    ...
+    ibcfeetypes.ModuleName,
+    ...
+)
+
+// Add packet forward middleware to init params keeper
+func initParamsKeeper(appCodec codec.BinaryCodec, legacyAmino *codec.LegacyAmino, key, tkey storetypes.StoreKey) paramskeeper.Keeper {
+    ...
+    paramsKeeper.Subspace(packetforwardtypes.ModuleName).WithKeyTable(packetforwardtypes.ParamKeyTable())
+    ...
+}
+```
+
+## Configuring the transfer application stack with Packet Forward Middleware
+
+Here is an example of how to create an application stack using `transfer` and `packet-forward-middleware`. 
+The following `transferStack` is configured in `app/app.go` and added to the IBC `Router`. 
+The in-line comments describe the execution flow of packets between the application stack and IBC core.
+
+For more information on configuring an IBC application stack see the ibc-go docs [here](https://github.com/cosmos/ibc-go/blob/main/docs/middleware/ics29-fee/integration.md#configuring-an-application-stack-with-fee-middleware).
+
+
+```go
+// Create Transfer Stack
+// SendPacket, since it is originating from the application to core IBC:
+// transferKeeper.SendPacket -> packetforward.SendPacket -> channel.SendPacket
+
+// RecvPacket, message that originates from core IBC and goes down to app, the flow is the other way
+// channel.RecvPacket -> packetforward.OnRecvPacket -> transfer.OnRecvPacket
+
+// transfer stack contains (from top to bottom):
+// - Packet Forward Middleware
+// - Transfer
+var transferStack ibcporttypes.IBCModule
+transferStack = transfer.NewIBCModule(app.TransferKeeper)
+transferStack = packetforward.NewIBCMiddleware(
+	transferStack,
+	app.PacketForwardKeeper,
+	0, // retries on timeout
+	packetforwardkeeper.DefaultForwardTransferPacketTimeoutTimestamp, // forward timeout
+	packetforwardkeeper.DefaultRefundTransferPacketTimeoutTimestamp, // refund timeout
+)
+
+// Add transfer stack to IBC Router
+ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
+```
+
+## Configurable options in the Packet Forward Middleware
+
+Provide description of these configurable params
+
+- Retries
+- Timeouts
+- Fee distribution to community pool

--- a/middleware/packet-forward-middleware/docs/integration.md
+++ b/middleware/packet-forward-middleware/docs/integration.md
@@ -3,6 +3,13 @@ This document provides instructions on integrating and configuring the Packet Fo
 existing chain implementation. This document is _NOT_ a guide on developing with the Cosmos SDK or ibc-go and makes
 the assumption that you have some existing codebase for your chain with IBC already enabled.
 
+The integration steps include the following:
+1. Import the PFM, initialize the PFM Module & Keeper, initialize the store keys and module params, and initialize the Begin/End Block logic and InitGenesis order.
+2. Configure the IBC application stack including the transfer module.
+3. Configuration of additional options such as timeout period, number of retries on timeout, refund timeout period, and fee percentage.
+
+Integration of the PFM should take approximately 20 minutes.
+
 ## Example integration of the Packet Forward Middleware
 
 ```go
@@ -149,8 +156,17 @@ ibcRouter.AddRoute(ibctransfertypes.ModuleName, transferStack)
 
 ## Configurable options in the Packet Forward Middleware
 
-Provide description of these configurable params
+The Packet Forward Middleware has several configurable options available when initializing the IBC application stack. 
+You can see these passed in as arguments to `packetforward.NewIBCMiddleware` and they include the number of retries that
+will be performed on a forward timeout, the timeout period that will be used for a forward, and the timeout period that
+will be used for performing refunds in the case that a forward is taking too long.
 
-- Retries
-- Timeouts
-- Fee distribution to community pool
+Additionally, there is a fee percentage parameter that can be set in `InitGenesis`, this is an optional parameter that
+can be used to take a fee from each forwarded packet which will then be distributed to the community pool. In the 
+`OnRecvPacket` callback `ForwardTransferPacket` is invoked which will attempt to subtract a fee from the forwarded
+packet amount if the fee percentage is non-zero.
+
+- Retries On Timeout - how many times will a forward be re-attempted in the case of a timeout.
+- Timeout Period - how long can a forward be in progress before giving up.
+- Refund Timeout - how long can a forward be in progress before issuing a refund back to the original source chain.
+- Fee Percentage - % of the forwarded packet amount which will be subtracted and distributed to the community pool.


### PR DESCRIPTION
A doc containing instructions on how to integrate the packet forward middleware with an existing Cosmos chain. 
I tried to keep this doc similar to the integration doc found [here](https://github.com/cosmos/ibc-go/blob/main/docs/middleware/ics29-fee/integration.md) for the ics29-fee middleware.

Read the rendered doc [here](https://github.com/cosmos/ibc-apps/blob/9da2bda6f007dd8f8b676c9d22f00eb52d831726/middleware/packet-forward-middleware/docs/integration.md)