### PR TITLE
docs: fix typo in pfm integration doc

### DIFF
--- a/middleware/packet-forward-middleware/docs/integration.md
+++ b/middleware/packet-forward-middleware/docs/integration.md
@@ -108,7 +108,7 @@ app.moduleManager.SetOrderEndBlockers(
 // Add packet forward middleware to init genesis logic
 app.moduleManager.SetOrderInitGenesis(
     ...
-    ibcfeetypes.ModuleName,
+    packetforwardtypes.ModuleName,
     ...
 )
 


### PR DESCRIPTION
Missed a typo when handling code review on the integration doc for the PFM