### PR TITLE
fix: mergify backport label

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -15,7 +15,7 @@ pull_request_rules:
             - "{{ author }}"
         labels:
           - automerge
-          - backport
+          - backported
         title: "`[BP: {{ destination_branch }} <- #{{ number }}]` {{ title }}"
 
   - name: automerge backported PR's for maintained branches


### PR DESCRIPTION
We don't want mergify to label the backported PR's with the `BACKPORT` label, else it will get in a backport loop!

Lets label with `backported` instead.