### PR TITLE
fix: validate proposed genesis state in InitGenesis

### DIFF
--- a/middleware/packet-forward-middleware/Makefile
+++ b/middleware/packet-forward-middleware/Makefile
@@ -147,6 +147,7 @@ mocks: $(MOCKS_DIR)
 	mockgen -package=mock -destination=./test/mock/bank_keeper.go $(GOMOD)/router/types BankKeeper
 	mockgen -package=mock -destination=./test/mock/ics4_wrapper.go github.com/cosmos/ibc-go/v7/modules/core/05-port/types ICS4Wrapper
 	mockgen -package=mock -destination=./test/mock/ibc_module.go github.com/cosmos/ibc-go/v7/modules/core/05-port/types IBCModule
+	mockgen -package=mock -destination=./test/mock/channel_keeper.go $(GOMOD)/router/types ChannelKeeper
 
 .PHONY: mocks
 

--- a/middleware/packet-forward-middleware/go.mod
+++ b/middleware/packet-forward-middleware/go.mod
@@ -6,17 +6,16 @@ require (
 	cosmossdk.io/errors v1.0.0-beta.7
 	github.com/armon/go-metrics v0.4.1
 	github.com/cometbft/cometbft v0.37.0
-	github.com/cometbft/cometbft-db v0.7.0
 	github.com/cosmos/cosmos-sdk v0.47.0
 	github.com/cosmos/gogoproto v1.4.6
 	github.com/cosmos/ibc-go/v7 v7.0.0
-	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.3
 	github.com/gorilla/mux v1.8.0
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0
 	github.com/iancoleman/orderedmap v0.2.0
 	github.com/spf13/cobra v1.6.1
 	github.com/stretchr/testify v1.8.2
+	go.uber.org/mock v0.2.0
 	google.golang.org/genproto v0.0.0-20230216225411-c8e22ba71e44
 	google.golang.org/grpc v1.53.0
 )
@@ -36,6 +35,7 @@ require (
 	github.com/cespare/xxhash v1.1.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chzyer/readline v1.5.1 // indirect
+	github.com/cometbft/cometbft-db v0.7.0 // indirect
 	github.com/confio/ics23/go v0.9.0 // indirect
 	github.com/cosmos/btcutil v1.0.5 // indirect
 	github.com/cosmos/cosmos-proto v1.0.0-beta.2 // indirect

--- a/middleware/packet-forward-middleware/go.sum
+++ b/middleware/packet-forward-middleware/go.sum
@@ -225,7 +225,6 @@ github.com/golang/mock v1.4.1/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/mock v1.4.4/go.mod h1:l3mdAwkq5BuhzHwde/uurv3sEJeZMXNpwsxVWU71h+4=
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.0/go.mod h1:Qd/q+1AKNOZr9uGQzbzCmRO6sUih6GTPZv6a1/R87v0=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -516,7 +515,6 @@ github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9de
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
-github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zondax/hid v0.9.1 h1:gQe66rtmyZ8VeGFcOpbuH3r7erYtNEAezCAYu8LdkJo=
 github.com/zondax/hid v0.9.1/go.mod h1:l5wttcP0jwtdLjqjMMWFVEE7d1zO0jvSPA9OPZxWpEM=
 github.com/zondax/ledger-go v0.14.1 h1:Pip65OOl4iJ84WTpA4BKChvOufMhhbxED3BaihoZN4c=
@@ -531,6 +529,8 @@ go.opencensus.io v0.22.4/go.mod h1:yxeiOL68Rb0Xd1ddK5vPZ/oVn4vY4Ynel7k9FzqtOIw=
 go.opencensus.io v0.22.5/go.mod h1:5pWMHQbX5EPX2/62yrJeAkowc+lfs/XD7Uxpq3pI6kk=
 go.opencensus.io v0.24.0 h1:y73uSU6J157QMP2kn2r30vwW1A2W2WFwSCGnAVxeaD0=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/mock v0.2.0 h1:TaP3xedm7JaAgScZO7tlvlKrqT0p7I6OsdGB5YNSMDU=
+go.uber.org/mock v0.2.0/go.mod h1:J0y0rp9L3xiff1+ZBfKxlC1fz2+aO16tw0tsDOixfuM=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
@@ -581,7 +581,6 @@ golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.4.1/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/mod v0.4.2/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180906233101-161cd47e91fd/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -617,7 +616,6 @@ golang.org/x/net v0.0.0-20201031054903-ff519b6c9102/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20201209123823-ac852fbbde11/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20201224014010-6772e930b67b/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
-golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20220225172249-27dd8689420f/go.mod h1:CfG3xpIq0wQ8r1q4Su4UZFWDARRcnwPjda9FqA0JpMk=
 golang.org/x/net v0.0.0-20220607020251-c690dde0001d/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
@@ -643,7 +641,6 @@ golang.org/x/sync v0.0.0-20200317015054-43a5402ce75a/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -687,10 +684,8 @@ golang.org/x/sys v0.0.0-20210104204734-6f8348627aad/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210112080510-489259a85091/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210225134936-a50acf3fe073/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210819135213-f52c844e1c1c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -769,7 +764,6 @@ golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20210106214847-113979e3529a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0/go.mod h1:xkSsbof2nBLbhDlRMhhhyNLN/zl3eTqcnHD5viDpcZ0=
-golang.org/x/tools v0.1.1/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/middleware/packet-forward-middleware/router/keeper/params.go
+++ b/middleware/packet-forward-middleware/router/keeper/params.go
@@ -6,19 +6,19 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
-// GetSendEnabled retrieves the send enabled boolean from the paramstore
+// GetFeePercentage retrieves the fee percentage for forwarded packets from the store.
 func (k Keeper) GetFeePercentage(ctx sdk.Context) sdk.Dec {
 	var res sdk.Dec
 	k.paramSpace.Get(ctx, types.KeyFeePercentage, &res)
 	return res
 }
 
-// GetParams returns the total set of ibc-transfer parameters.
+// GetParams returns the total set of pfm parameters.
 func (k Keeper) GetParams(ctx sdk.Context) types.Params {
 	return types.NewParams(k.GetFeePercentage(ctx))
 }
 
-// SetParams sets the total set of ibc-transfer parameters.
+// SetParams sets the total set of pfm parameters.
 func (k Keeper) SetParams(ctx sdk.Context, params types.Params) {
 	k.paramSpace.SetParamSet(ctx, &params)
 }

--- a/middleware/packet-forward-middleware/router/module.go
+++ b/middleware/packet-forward-middleware/router/module.go
@@ -102,6 +102,11 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 // InitGenesis performs genesis initialization for the ibc-router module. It returns
 // no validator updates.
 func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.RawMessage) []abci.ValidatorUpdate {
+	err := am.ValidateGenesis(cdc, nil, data)
+	if err != nil {
+		panic(err)
+	}
+
 	var genesisState types.GenesisState
 	cdc.MustUnmarshalJSON(data, &genesisState)
 	am.keeper.InitGenesis(ctx, genesisState)

--- a/middleware/packet-forward-middleware/router/module_test.go
+++ b/middleware/packet-forward-middleware/router/module_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/keeper"
 	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/types"
 	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/test"
-	"github.com/golang/mock/gomock"
 	"github.com/iancoleman/orderedmap"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
@@ -256,7 +256,7 @@ func TestOnRecvPacket_ForwardNoFee(t *testing.T) {
 		Channel:  channel,
 	}}
 	packetOrig := transferPacket(t, senderAddr, hostAddr, metadata)
-	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, metadata)
+	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, nil)
 	packetFwd := transferPacket(t, intermediateAddr, destAddr, nil)
 
 	acknowledgement := channeltypes.NewResultAcknowledgement([]byte("test"))
@@ -317,7 +317,7 @@ func TestOnRecvPacket_ForwardAmountInt256(t *testing.T) {
 	}}
 
 	packetOrig := transferPacket256(t, senderAddr, hostAddr, metadata)
-	packetModifiedSender := transferPacket256(t, senderAddr, intermediateAddr, metadata)
+	packetModifiedSender := transferPacket256(t, senderAddr, intermediateAddr, nil)
 	packetFwd := transferPacket256(t, intermediateAddr, destAddr, nil)
 
 	acknowledgement := channeltypes.NewResultAcknowledgement([]byte("test"))
@@ -378,7 +378,7 @@ func TestOnRecvPacket_ForwardWithFee(t *testing.T) {
 		Channel:  channel,
 	}}
 	packetOrig := transferPacket(t, senderAddr, hostAddr, metadata)
-	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, metadata)
+	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, nil)
 	packetFwd := transferPacket(t, intermediateAddr, destAddr, nil)
 	acknowledgement := channeltypes.NewResultAcknowledgement([]byte("test"))
 	successAck := cdc.MustMarshalJSON(&acknowledgement)
@@ -454,9 +454,9 @@ func TestOnRecvPacket_ForwardMultihopStringNext(t *testing.T) {
 	}
 
 	packetOrig := transferPacket(t, senderAddr, hostAddr, metadata)
-	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, metadata)
+	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, nil)
 	packet2 := transferPacket(t, intermediateAddr, hostAddr2, nextMetadata)
-	packet2ModifiedSender := transferPacket(t, intermediateAddr, intermediateAddr2, nextMetadata)
+	packet2ModifiedSender := transferPacket(t, intermediateAddr, intermediateAddr2, nil)
 	packetFwd := transferPacket(t, intermediateAddr2, destAddr, nil)
 
 	memo1, err := json.Marshal(nextMetadata)
@@ -566,9 +566,9 @@ func TestOnRecvPacket_ForwardMultihopJSONNext(t *testing.T) {
 		},
 	}
 	packetOrig := transferPacket(t, senderAddr, hostAddr, metadata)
-	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, metadata)
+	packetModifiedSender := transferPacket(t, senderAddr, intermediateAddr, nil)
 	packet2 := transferPacket(t, intermediateAddr, hostAddr2, nextMetadata)
-	packet2ModifiedSender := transferPacket(t, intermediateAddr, intermediateAddr2, nextMetadata)
+	packet2ModifiedSender := transferPacket(t, intermediateAddr, intermediateAddr2, nil)
 	packetFwd := transferPacket(t, intermediateAddr2, destAddr, nil)
 
 	memo1, err := json.Marshal(nextMetadata)

--- a/middleware/packet-forward-middleware/router/types/genesis.go
+++ b/middleware/packet-forward-middleware/router/types/genesis.go
@@ -1,6 +1,6 @@
 package types
 
-// NewGenesisState creates a 29-fee GenesisState instance.
+// NewGenesisState creates a pfm GenesisState instance.
 func NewGenesisState(params Params, inFlightPackets map[string]InFlightPacket) *GenesisState {
 	return &GenesisState{
 		Params:          params,
@@ -8,7 +8,7 @@ func NewGenesisState(params Params, inFlightPackets map[string]InFlightPacket) *
 	}
 }
 
-// DefaultGenesisState returns a GenesisState with "transfer" as the default PortID.
+// DefaultGenesisState returns a GenesisState with a default fee percentage of 0.
 func DefaultGenesisState() *GenesisState {
 	return &GenesisState{
 		Params:          DefaultParams(),
@@ -16,8 +16,7 @@ func DefaultGenesisState() *GenesisState {
 	}
 }
 
-// Validate performs basic genesis state validation returning an error upon any
-// failure.
+// Validate performs basic genesis state validation returning an error upon any failure.
 func (gs GenesisState) Validate() error {
 	return gs.Params.Validate()
 }

--- a/middleware/packet-forward-middleware/router/types/params.go
+++ b/middleware/packet-forward-middleware/router/types/params.go
@@ -1,47 +1,50 @@
 package types
 
 import (
-	fmt "fmt"
+	"fmt"
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	paramtypes "github.com/cosmos/cosmos-sdk/x/params/types"
 )
 
 var (
+	// DefaultFeePercentage is the default value used to extract a fee from all forwarded packets.
 	DefaultFeePercentage = sdk.NewDec(0)
+
 	// KeyFeePercentage is store's key for FeePercentage Params
 	KeyFeePercentage = []byte("FeePercentage")
 )
 
-// ParamKeyTable type declaration for parameters
+// ParamKeyTable type declaration for parameters.
 func ParamKeyTable() paramtypes.KeyTable {
 	return paramtypes.NewKeyTable().RegisterParamSet(&Params{})
 }
 
-// NewParams creates a new parameter configuration for the ibc transfer module
+// NewParams creates a new parameter configuration for the pfm module.
 func NewParams(feePercentage sdk.Dec) Params {
 	return Params{
 		FeePercentage: feePercentage,
 	}
 }
 
-// DefaultParams is the default parameter configuration for the ibc-transfer module
+// DefaultParams is the default parameter configuration for the pfm module.
 func DefaultParams() Params {
 	return NewParams(DefaultFeePercentage)
 }
 
-// Validate all ibc-transfer module parameters
+// Validate the pfm module parameters.
 func (p Params) Validate() error {
 	return validateFeePercentage(p.FeePercentage)
 }
 
-// ParamSetPairs implements params.ParamSet
+// ParamSetPairs implements params.ParamSet.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
 		paramtypes.NewParamSetPair(KeyFeePercentage, p.FeePercentage, validateFeePercentage),
 	}
 }
 
+// validateFeePercentage asserts that the fee percentage param is a valid sdk.Dec type.
 func validateFeePercentage(i interface{}) error {
 	v, ok := i.(sdk.Dec)
 	if !ok {

--- a/middleware/packet-forward-middleware/test/mock/bank_keeper.go
+++ b/middleware/packet-forward-middleware/test/mock/bank_keeper.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	types "github.com/cosmos/cosmos-sdk/types"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockBankKeeper is a mock of BankKeeper interface.

--- a/middleware/packet-forward-middleware/test/mock/channel_keeper.go
+++ b/middleware/packet-forward-middleware/test/mock/channel_keeper.go
@@ -10,7 +10,7 @@ import (
 	types "github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/cosmos-sdk/x/capability/types"
 	types1 "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockChannelKeeper is a mock of ChannelKeeper interface.

--- a/middleware/packet-forward-middleware/test/mock/distribution_keeper.go
+++ b/middleware/packet-forward-middleware/test/mock/distribution_keeper.go
@@ -8,7 +8,7 @@ import (
 	reflect "reflect"
 
 	types "github.com/cosmos/cosmos-sdk/types"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockDistributionKeeper is a mock of DistributionKeeper interface.

--- a/middleware/packet-forward-middleware/test/mock/ibc_module.go
+++ b/middleware/packet-forward-middleware/test/mock/ibc_module.go
@@ -11,7 +11,7 @@ import (
 	types0 "github.com/cosmos/cosmos-sdk/x/capability/types"
 	types1 "github.com/cosmos/ibc-go/v7/modules/core/04-channel/types"
 	exported "github.com/cosmos/ibc-go/v7/modules/core/exported"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockIBCModule is a mock of IBCModule interface.

--- a/middleware/packet-forward-middleware/test/mock/ics4_wrapper.go
+++ b/middleware/packet-forward-middleware/test/mock/ics4_wrapper.go
@@ -11,7 +11,7 @@ import (
 	types0 "github.com/cosmos/cosmos-sdk/x/capability/types"
 	types1 "github.com/cosmos/ibc-go/v7/modules/core/02-client/types"
 	exported "github.com/cosmos/ibc-go/v7/modules/core/exported"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockICS4Wrapper is a mock of ICS4Wrapper interface.

--- a/middleware/packet-forward-middleware/test/mock/transfer_keeper.go
+++ b/middleware/packet-forward-middleware/test/mock/transfer_keeper.go
@@ -10,7 +10,7 @@ import (
 
 	types "github.com/cosmos/cosmos-sdk/types"
 	types0 "github.com/cosmos/ibc-go/v7/modules/apps/transfer/types"
-	gomock "github.com/golang/mock/gomock"
+	gomock "go.uber.org/mock/gomock"
 )
 
 // MockTransferKeeper is a mock of TransferKeeper interface.

--- a/middleware/packet-forward-middleware/test/setup.go
+++ b/middleware/packet-forward-middleware/test/setup.go
@@ -8,8 +8,8 @@ import (
 	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/keeper"
 	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/router/types"
 	"github.com/cosmos/ibc-apps/middleware/packet-forward-middleware/v7/test/mock"
-	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
 
 	"github.com/cosmos/cosmos-sdk/codec"
 	cdctypes "github.com/cosmos/cosmos-sdk/codec/types"


### PR DESCRIPTION
When genesis initialization takes place in `InitGenesis` we were not explicitly calling `ValidateGenesis` on the proposed genesis state. This was allowing invalid data to be written to the store.

Closes #46 