### PR TITLE
Fix PFM to not fail packets that aren't `FungibleTokenPacketData`

### DIFF
--- a/middleware/packet-forward-middleware/router/ibc_middleware.go
+++ b/middleware/packet-forward-middleware/router/ibc_middleware.go
@@ -170,8 +170,8 @@ func (im IBCMiddleware) OnRecvPacket(
 
 	var data transfertypes.FungibleTokenPacketData
 	if err := transfertypes.ModuleCdc.UnmarshalJSON(packet.GetData(), &data); err != nil {
-		logger.Error("packetForwardMiddleware OnRecvPacketfailed to unmarshal packet data as FungibleTokenPacketData", "error", err)
-		return newErrorAcknowledgement(fmt.Errorf("failed to unmarshal packet data as FungibleTokenPacketData: %w", err))
+		logger.Debug(fmt.Sprintf("packetForwardMiddleware OnRecvPacket payload is not a FungibleTokenPacketData: %s", err.Error()))
+		return im.app.OnRecvPacket(ctx, packet, relayer)
 	}
 
 	logger.Debug("packetForwardMiddleware OnRecvPacket",


### PR DESCRIPTION
Currently, PFM fails packets that are not `FungibleTokenPacketData`. This means that PFM cannot support IBC apps that don't exclusively use `FungibleTokenPacketData` as the payload format (i.e., ics20-* or the transfer app). Therefore, CosmWasm cannot have PFM in its IBC stack, even though CosmWasm contracts may implement the ics20-* protocol (e.g., cw20-ics20: https://github.com/CosmWasm/cw-plus/tree/HEAD/contracts/cw20-ics20).

This commit fixes the issue by passing the packet forward in the stack rather than failing packets that are not `FungibleTokenPacketData`.

This will allow PFM to support a wider range of IBC apps and will make it possible for CosmWasm to have PFM in its IBC stack, which will improve the interoperability and usability of PFM in the Cosmos ecosystem