### PR TITLE
chore: export the GetReceiver function

### DIFF
--- a/middleware/packet-forward-middleware/packetforward/ibc_middleware.go
+++ b/middleware/packet-forward-middleware/packetforward/ibc_middleware.go
@@ -136,11 +136,11 @@ func getBoolFromAny(value any) bool {
 	return boolVal
 }
 
-// getReceiver returns the receiver address for a given channel and original sender.
+// GetReceiver returns the receiver address for a given channel and original sender.
 // it overrides the receiver address to be a hash of the channel/origSender so that
 // the receiver address is deterministic and can be used to identify the sender on the
 // initial chain.
-func getReceiver(channel string, originalSender string) (string, error) {
+func GetReceiver(channel string, originalSender string) (string, error) {
 	senderStr := fmt.Sprintf("%s/%s", channel, originalSender)
 	senderHash32 := address.Hash(types.ModuleName, []byte(senderStr))
 	sender := sdk.AccAddress(senderHash32[:20])
@@ -208,7 +208,7 @@ func (im IBCMiddleware) OnRecvPacket(
 	}
 
 	// override the receiver so that senders cannot move funds through arbitrary addresses.
-	overrideReceiver, err := getReceiver(packet.DestinationChannel, data.Sender)
+	overrideReceiver, err := GetReceiver(packet.DestinationChannel, data.Sender)
 	if err != nil {
 		logger.Error("packetForwardMiddleware OnRecvPacket failed to construct override receiver", "error", err)
 		return newErrorAcknowledgement(fmt.Errorf("failed to construct override receiver: %w", err))


### PR DESCRIPTION
This PR exports the `GetReceiver` function. As noted in #131 there are cases where other middleware in the stack may need to make use of this receiver address.

Closes #131 