### PR TITLE
Fix: migrate PFM from 1 to 2

### DIFF
--- a/middleware/packet-forward-middleware/packetforward/module.go
+++ b/middleware/packet-forward-middleware/packetforward/module.go
@@ -109,7 +109,7 @@ func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
 
 	m := keeper.NewMigrator(am.keeper, am.legacySubspace)
-	if err := cfg.RegisterMigration(types.ModuleName, 2, m.Migrate1to2); err != nil {
+	if err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2); err != nil {
 		panic(fmt.Sprintf("failed to migrate x/%s from version 1 to 2: %v", types.ModuleName, err))
 	}
 }

--- a/middleware/packet-forward-middleware/packetforward/types/params_legacy.go
+++ b/middleware/packet-forward-middleware/packetforward/types/params_legacy.go
@@ -20,6 +20,6 @@ func ParamKeyTable() paramtypes.KeyTable {
 // ParamSetPairs implements params.ParamSet.
 func (p *Params) ParamSetPairs() paramtypes.ParamSetPairs {
 	return paramtypes.ParamSetPairs{
-		paramtypes.NewParamSetPair(KeyFeePercentage, p.FeePercentage, validateFeePercentage),
+		paramtypes.NewParamSetPair(KeyFeePercentage, &p.FeePercentage, validateFeePercentage),
 	}
 }


### PR DESCRIPTION
This PR fixes:
* a proper `fromVersion` argument for migrating from v1 to v2;
* a proper `p.FeePercentage` type for legacy `ParamSetPairs`

**Without theses changes it's impossible to migrate to v7.1.0 version of PFM**