### PR TITLE
fix: mint and transfer funds back to escrow account on timeout or ack error

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -25,6 +25,6 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.52
+          version: v1.55.2
           working-directory: ${{ matrix.workdir }}
           args: --timeout=5m

--- a/middleware/packet-forward-middleware/e2e/forward_timeout_test.go
+++ b/middleware/packet-forward-middleware/e2e/forward_timeout_test.go
@@ -201,7 +201,7 @@ func TestTimeoutOnForward(t *testing.T) {
 	time.Sleep(time.Second * 11)
 
 	// Restart the relayer
-	err = r.StartRelayer(ctx, eRep, pathAB, pathBC)
+	err = r.StartRelayer(ctx, eRep, pathAB, pathBC, pathCD)
 	require.NoError(t, err)
 
 	chainAHeight, err := chainA.Height(ctx)
@@ -249,4 +249,149 @@ func TestTimeoutOnForward(t *testing.T) {
 	require.True(t, firstHopEscrowBalance.Equal(zeroBal))
 	require.True(t, secondHopEscrowBalance.Equal(zeroBal))
 	require.True(t, thirdHopEscrowBalance.Equal(zeroBal))
+
+	// Send IBC transfer from ChainA -> ChainB -> ChainC -> ChainD that will succeed
+	secondHopMetadata = &PacketMetadata{
+		Forward: &ForwardMetadata{
+			Receiver: userD.FormattedAddress(),
+			Channel:  cdChan.ChannelID,
+			Port:     cdChan.PortID,
+		},
+	}
+	nextBz, err = json.Marshal(secondHopMetadata)
+	require.NoError(t, err)
+	next = string(nextBz)
+
+	firstHopMetadata = &PacketMetadata{
+		Forward: &ForwardMetadata{
+			Receiver: userC.FormattedAddress(),
+			Channel:  bcChan.ChannelID,
+			Port:     bcChan.PortID,
+			Next:     &next,
+		},
+	}
+
+	memo, err = json.Marshal(firstHopMetadata)
+	require.NoError(t, err)
+
+	opts = ibc.TransferOptions{
+		Memo: string(memo),
+	}
+
+	chainAHeight, err = chainA.Height(ctx)
+	require.NoError(t, err)
+
+	transferTx, err = chainA.SendIBCTransfer(ctx, abChan.ChannelID, userA.KeyName(), transfer, opts)
+	require.NoError(t, err)
+
+	_, err = testutil.PollForAck(ctx, chainA, chainAHeight, chainAHeight+30, transferTx.Packet)
+	require.NoError(t, err)
+
+	err = testutil.WaitForBlocks(ctx, 5, chainA)
+	require.NoError(t, err)
+
+	// Assert balances are updated to reflect tokens now being on ChainD
+	chainABalance, err = chainA.GetBalance(ctx, userA.FormattedAddress(), chainA.Config().Denom)
+	require.NoError(t, err)
+
+	chainBBalance, err = chainB.GetBalance(ctx, userB.FormattedAddress(), firstHopIBCDenom)
+	require.NoError(t, err)
+
+	chainCBalance, err = chainC.GetBalance(ctx, userC.FormattedAddress(), secondHopIBCDenom)
+	require.NoError(t, err)
+
+	chainDBalance, err = chainD.GetBalance(ctx, userD.FormattedAddress(), thirdHopIBCDenom)
+	require.NoError(t, err)
+
+	require.True(t, chainABalance.Equal(initBal.Sub(transferAmount)))
+	require.True(t, chainBBalance.Equal(zeroBal))
+	require.True(t, chainCBalance.Equal(zeroBal))
+	require.True(t, chainDBalance.Equal(transferAmount))
+
+	firstHopEscrowBalance, err = chainA.GetBalance(ctx, firstHopEscrowAccount, chainA.Config().Denom)
+	require.NoError(t, err)
+
+	secondHopEscrowBalance, err = chainB.GetBalance(ctx, secondHopEscrowAccount, firstHopIBCDenom)
+	require.NoError(t, err)
+
+	thirdHopEscrowBalance, err = chainC.GetBalance(ctx, thirdHopEscrowAccount, secondHopIBCDenom)
+	require.NoError(t, err)
+
+	require.True(t, firstHopEscrowBalance.Equal(transferAmount))
+	require.True(t, secondHopEscrowBalance.Equal(transferAmount))
+	require.True(t, thirdHopEscrowBalance.Equal(transferAmount))
+
+	// Compose IBC tx that will attempt to go from ChainD -> ChainC -> ChainB -> ChainA but timeout between ChainB->ChainA
+	transfer = ibc.WalletAmount{
+		Address: userC.FormattedAddress(),
+		Denom:   thirdHopDenom,
+		Amount:  transferAmount,
+	}
+
+	secondHopMetadata = &PacketMetadata{
+		Forward: &ForwardMetadata{
+			Receiver: userA.FormattedAddress(),
+			Channel:  baChan.ChannelID,
+			Port:     baChan.PortID,
+			Timeout:  1 * time.Second,
+		},
+	}
+	nextBz, err = json.Marshal(secondHopMetadata)
+	require.NoError(t, err)
+	next = string(nextBz)
+
+	firstHopMetadata = &PacketMetadata{
+		Forward: &ForwardMetadata{
+			Receiver: userB.FormattedAddress(),
+			Channel:  cbChan.ChannelID,
+			Port:     cbChan.PortID,
+			Next:     &next,
+		},
+	}
+
+	memo, err = json.Marshal(firstHopMetadata)
+	require.NoError(t, err)
+
+	chainDHeight, err := chainD.Height(ctx)
+	require.NoError(t, err)
+
+	transferTx, err = chainD.SendIBCTransfer(ctx, dcChan.ChannelID, userD.KeyName(), transfer, ibc.TransferOptions{Memo: string(memo)})
+	require.NoError(t, err)
+
+	_, err = testutil.PollForAck(ctx, chainD, chainDHeight, chainDHeight+25, transferTx.Packet)
+	require.NoError(t, err)
+
+	err = testutil.WaitForBlocks(ctx, 5, chainD)
+	require.NoError(t, err)
+
+	// Assert balances to ensure timeout happened and user funds are still present on ChainD
+	chainABalance, err = chainA.GetBalance(ctx, userA.FormattedAddress(), chainA.Config().Denom)
+	require.NoError(t, err)
+
+	chainBBalance, err = chainB.GetBalance(ctx, userB.FormattedAddress(), firstHopIBCDenom)
+	require.NoError(t, err)
+
+	chainCBalance, err = chainC.GetBalance(ctx, userC.FormattedAddress(), secondHopIBCDenom)
+	require.NoError(t, err)
+
+	chainDBalance, err = chainD.GetBalance(ctx, userD.FormattedAddress(), thirdHopIBCDenom)
+	require.NoError(t, err)
+
+	require.True(t, chainABalance.Equal(initBal.Sub(transferAmount)))
+	require.True(t, chainBBalance.Equal(zeroBal))
+	require.True(t, chainCBalance.Equal(zeroBal))
+	require.True(t, chainDBalance.Equal(transferAmount))
+
+	firstHopEscrowBalance, err = chainA.GetBalance(ctx, firstHopEscrowAccount, chainA.Config().Denom)
+	require.NoError(t, err)
+
+	secondHopEscrowBalance, err = chainB.GetBalance(ctx, secondHopEscrowAccount, firstHopIBCDenom)
+	require.NoError(t, err)
+
+	thirdHopEscrowBalance, err = chainC.GetBalance(ctx, thirdHopEscrowAccount, secondHopIBCDenom)
+	require.NoError(t, err)
+
+	require.True(t, firstHopEscrowBalance.Equal(transferAmount))
+	require.True(t, secondHopEscrowBalance.Equal(transferAmount))
+	require.True(t, thirdHopEscrowBalance.Equal(transferAmount))
 }

--- a/middleware/packet-forward-middleware/packetforward/keeper/keeper.go
+++ b/middleware/packet-forward-middleware/packetforward/keeper/keeper.go
@@ -140,47 +140,56 @@ func (k *Keeper) WriteAcknowledgementForForwardedPacket(
 			}
 		}
 
+		amount, ok := sdk.NewIntFromString(data.Amount)
+		if !ok {
+			return fmt.Errorf("failed to parse amount from packet data for forward refund: %s", data.Amount)
+		}
+
+		denomTrace := transfertypes.ParseDenomTrace(fullDenomPath)
+		token := sdk.NewCoin(denomTrace.IBCDenom(), amount)
+
+		escrowAddress := transfertypes.GetEscrowAddress(packet.SourcePort, packet.SourceChannel)
+		refundEscrowAddress := transfertypes.GetEscrowAddress(inFlightPacket.RefundPortId, inFlightPacket.RefundChannelId)
+
+		newToken := sdk.NewCoins(token)
+
 		if transfertypes.SenderChainIsSource(packet.SourcePort, packet.SourceChannel, fullDenomPath) {
 			// funds were moved to escrow account for transfer, so they need to either:
 			// - move to the other escrow account, in the case of native denom
 			// - burn
-
-			amount, ok := sdk.NewIntFromString(data.Amount)
-			if !ok {
-				return fmt.Errorf("failed to parse amount from packet data for forward refund: %s", data.Amount)
-			}
-			denomTrace := transfertypes.ParseDenomTrace(fullDenomPath)
-			token := sdk.NewCoin(denomTrace.IBCDenom(), amount)
-
-			escrowAddress := transfertypes.GetEscrowAddress(packet.SourcePort, packet.SourceChannel)
-
 			if transfertypes.SenderChainIsSource(inFlightPacket.RefundPortId, inFlightPacket.RefundChannelId, fullDenomPath) {
 				// transfer funds from escrow account for forwarded packet to escrow account going back for refund.
-
-				refundEscrowAddress := transfertypes.GetEscrowAddress(inFlightPacket.RefundPortId, inFlightPacket.RefundChannelId)
-
 				if err := k.bankKeeper.SendCoins(
-					ctx, escrowAddress, refundEscrowAddress, sdk.NewCoins(token),
+					ctx, escrowAddress, refundEscrowAddress, newToken,
 				); err != nil {
 					return fmt.Errorf("failed to send coins from escrow account to refund escrow account: %w", err)
 				}
 			} else {
 				// transfer the coins from the escrow account to the module account and burn them.
-
 				if err := k.bankKeeper.SendCoinsFromAccountToModule(
-					ctx, escrowAddress, transfertypes.ModuleName, sdk.NewCoins(token),
+					ctx, escrowAddress, transfertypes.ModuleName, newToken,
 				); err != nil {
 					return fmt.Errorf("failed to send coins from escrow to module account for burn: %w", err)
 				}
 
 				if err := k.bankKeeper.BurnCoins(
-					ctx, transfertypes.ModuleName, sdk.NewCoins(token),
+					ctx, transfertypes.ModuleName, newToken,
 				); err != nil {
 					// NOTE: should not happen as the module account was
 					// retrieved on the step above and it has enough balace
 					// to burn.
 					panic(fmt.Sprintf("cannot burn coins after a successful send from escrow account to module account: %v", err))
 				}
+			}
+		} else {
+			// Funds in the escrow account were burned,
+			// so on a timeout or acknowledgement error we need to mint the funds back to the escrow account.
+			if err := k.bankKeeper.MintCoins(ctx, transfertypes.ModuleName, newToken); err != nil {
+				return fmt.Errorf("cannot mint coins to the %s module account: %v", transfertypes.ModuleName, err)
+			}
+
+			if err := k.bankKeeper.SendCoinsFromModuleToAccount(ctx, transfertypes.ModuleName, refundEscrowAddress, newToken); err != nil {
+				return fmt.Errorf("cannot send coins from the %s module to the escrow account %s: %v", transfertypes.ModuleName, refundEscrowAddress, err)
 			}
 		}
 	}

--- a/middleware/packet-forward-middleware/packetforward/types/expected_keepers.go
+++ b/middleware/packet-forward-middleware/packetforward/types/expected_keepers.go
@@ -32,8 +32,8 @@ type DistributionKeeper interface {
 // BankKeeper defines the expected bank keeper
 type BankKeeper interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
-	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx sdk.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
-	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
+	MintCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 }

--- a/middleware/packet-forward-middleware/packetforward/types/expected_keepers.go
+++ b/middleware/packet-forward-middleware/packetforward/types/expected_keepers.go
@@ -32,6 +32,8 @@ type DistributionKeeper interface {
 // BankKeeper defines the expected bank keeper
 type BankKeeper interface {
 	SendCoins(ctx sdk.Context, fromAddr sdk.AccAddress, toAddr sdk.AccAddress, amt sdk.Coins) error
+	SendCoinsFromModuleToAccount(ctx context.Context, senderModule string, recipientAddr sdk.AccAddress, amt sdk.Coins) error
 	SendCoinsFromAccountToModule(ctx sdk.Context, senderAddr sdk.AccAddress, recipientModule string, amt sdk.Coins) error
+	MintCoins(ctx context.Context, moduleName string, amt sdk.Coins) error
 	BurnCoins(ctx sdk.Context, moduleName string, amt sdk.Coins) error
 }

--- a/middleware/packet-forward-middleware/test/mock/bank_keeper.go
+++ b/middleware/packet-forward-middleware/test/mock/bank_keeper.go
@@ -5,7 +5,6 @@
 package mock
 
 import (
-	context "context"
 	reflect "reflect"
 
 	types "github.com/cosmos/cosmos-sdk/types"
@@ -50,7 +49,7 @@ func (mr *MockBankKeeperMockRecorder) BurnCoins(arg0, arg1, arg2 interface{}) *g
 }
 
 // MintCoins mocks base method.
-func (m *MockBankKeeper) MintCoins(arg0 context.Context, arg1 string, arg2 types.Coins) error {
+func (m *MockBankKeeper) MintCoins(arg0 types.Context, arg1 string, arg2 types.Coins) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MintCoins", arg0, arg1, arg2)
 	ret0, _ := ret[0].(error)
@@ -92,7 +91,7 @@ func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(arg0, arg1, a
 }
 
 // SendCoinsFromModuleToAccount mocks base method.
-func (m *MockBankKeeper) SendCoinsFromModuleToAccount(arg0 context.Context, arg1 string, arg2 types.AccAddress, arg3 types.Coins) error {
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(arg0 types.Context, arg1 string, arg2 types.AccAddress, arg3 types.Coins) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SendCoinsFromModuleToAccount", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(error)

--- a/middleware/packet-forward-middleware/test/mock/bank_keeper.go
+++ b/middleware/packet-forward-middleware/test/mock/bank_keeper.go
@@ -5,6 +5,7 @@
 package mock
 
 import (
+	context "context"
 	reflect "reflect"
 
 	types "github.com/cosmos/cosmos-sdk/types"
@@ -48,6 +49,20 @@ func (mr *MockBankKeeperMockRecorder) BurnCoins(arg0, arg1, arg2 interface{}) *g
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BurnCoins", reflect.TypeOf((*MockBankKeeper)(nil).BurnCoins), arg0, arg1, arg2)
 }
 
+// MintCoins mocks base method.
+func (m *MockBankKeeper) MintCoins(arg0 context.Context, arg1 string, arg2 types.Coins) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "MintCoins", arg0, arg1, arg2)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// MintCoins indicates an expected call of MintCoins.
+func (mr *MockBankKeeperMockRecorder) MintCoins(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MintCoins", reflect.TypeOf((*MockBankKeeper)(nil).MintCoins), arg0, arg1, arg2)
+}
+
 // SendCoins mocks base method.
 func (m *MockBankKeeper) SendCoins(arg0 types.Context, arg1, arg2 types.AccAddress, arg3 types.Coins) error {
 	m.ctrl.T.Helper()
@@ -74,4 +89,18 @@ func (m *MockBankKeeper) SendCoinsFromAccountToModule(arg0 types.Context, arg1 t
 func (mr *MockBankKeeperMockRecorder) SendCoinsFromAccountToModule(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromAccountToModule", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromAccountToModule), arg0, arg1, arg2, arg3)
+}
+
+// SendCoinsFromModuleToAccount mocks base method.
+func (m *MockBankKeeper) SendCoinsFromModuleToAccount(arg0 context.Context, arg1 string, arg2 types.AccAddress, arg3 types.Coins) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SendCoinsFromModuleToAccount", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SendCoinsFromModuleToAccount indicates an expected call of SendCoinsFromModuleToAccount.
+func (mr *MockBankKeeperMockRecorder) SendCoinsFromModuleToAccount(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SendCoinsFromModuleToAccount", reflect.TypeOf((*MockBankKeeper)(nil).SendCoinsFromModuleToAccount), arg0, arg1, arg2, arg3)
 }


### PR DESCRIPTION
Previously we were failing to mint and transfer funds back to the escrow account in the case of a timeout or acknowledgement error but were still issuing the refund back to the sending chain. For forwards that involved IBC assets that were wrapped two or more times, this would result in the escrow account balance being less than the total supply of tokens on the counterparty.