### PR TITLE
chore(pfm): update log line to match function name

### DIFF
--- a/middleware/packet-forward-middleware/packetforward/ibc_middleware.go
+++ b/middleware/packet-forward-middleware/packetforward/ibc_middleware.go
@@ -361,7 +361,7 @@ func (im IBCMiddleware) OnTimeoutPacket(ctx sdk.Context, packet channeltypes.Pac
 		return im.app.OnTimeoutPacket(ctx, packet, relayer)
 	}
 
-	im.keeper.Logger(ctx).Debug("packetForwardMiddleware OnAcknowledgementPacket",
+	im.keeper.Logger(ctx).Debug("packetForwardMiddleware OnTimeoutPacket",
 		"sequence", packet.Sequence,
 		"src-channel", packet.SourceChannel, "src-port", packet.SourcePort,
 		"dst-channel", packet.DestinationChannel, "dst-port", packet.DestinationPort,


### PR DESCRIPTION
While looking at the code for PFM, I noticed this log line doesn't match the function name it's in, which could cause confusion for folks who look at logs. This PR should fix it