### PR TITLE
docs: update maintained branches table

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -2,14 +2,13 @@
 pull_request_rules:
   - name: backport to maintained branches
     conditions:
-      - base~=^(main|release/v4|release/v5|release/v6)$
+      - base~=^(main|release/v7|release/v6)$
       - label=BACKPORT
     actions:
       backport:
         branches:
           - main
-          - release/v4
-          - release/v5
+          - release/v7
           - release/v6
         assignees: 
             - "{{ author }}"
@@ -21,7 +20,7 @@ pull_request_rules:
   - name: automerge backported PR's for maintained branches
     conditions:
       - label=automerge
-      - base~=^(release/v4|release/v5|release/v6)$
+      - base~=^(release/v6|release/v7)$
     actions:
       merge:
         method: squash

--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ If you'd like to include software in this repo, please see [contributing](CONTRI
 |            [main](https://github.com/cosmos/ibc-apps)            |     v8     |
 | [release/v7](https://github.com/cosmos/ibc-apps/tree/release/v7) |     v7     |
 | [release/v6](https://github.com/cosmos/ibc-apps/tree/release/v6) |     v6     |
-| [release/v5](https://github.com/cosmos/ibc-apps/tree/release/v5) |     v5     |
-| [release/v4](https://github.com/cosmos/ibc-apps/tree/release/v4) |     v4     |
+
 
 ## List of Apps
 


### PR DESCRIPTION
Update the maintained branches table in README.md to reflect that we no longer maintain `release/v5` or `release/v4` due to the associated versions of ibc-go being EOL. Also, update mergify to reflect the currently maintained branches.