### PR TITLE
Typo fix README.md

### DIFF
--- a/cosmwasm/polytone/packages/polytone/src/handshake/README.md
+++ b/cosmwasm/polytone/packages/polytone/src/handshake/README.md
@@ -91,7 +91,7 @@ options. For example, for a version like:
 ["proto3-CosmosMsg", "JSON-CosmosMsg"]
 ```
 
-A selection method that prefered JSON would return:
+A selection method that preferred JSON would return:
 
 ```
 ["JSON-CosmosMsg"]


### PR DESCRIPTION
Fixed a typo in README.md. Improved clarity and ensured correctness by correcting the identified spelling or grammatical error.