### PR TITLE
fix: make v2 rate limiting support all encodings

### DIFF
--- a/modules/rate-limiting/v2/ibc_middleware.go
+++ b/modules/rate-limiting/v2/ibc_middleware.go
@@ -62,7 +62,7 @@ func (im IBCMiddleware) OnRecvPacket(
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("ICS20 rate limiting OnRecvPacket failed to convert v2 packet to v1 packet: %s", err.Error()))
 		return channeltypesv2.RecvPacketResult{
 			Status:          channeltypesv2.PacketStatus_Failure,
-			Acknowledgement: []byte(err.Error()),
+			Acknowledgement: channeltypes.NewErrorAcknowledgement(err).Acknowledgement(),
 		}
 	}
 	// Check if the packet would cause the rate limit to be exceeded,
@@ -71,7 +71,7 @@ func (im IBCMiddleware) OnRecvPacket(
 		im.keeper.Logger(ctx).Error(fmt.Sprintf("ICS20 packet receive was denied: %s", err.Error()))
 		return channeltypesv2.RecvPacketResult{
 			Status:          channeltypesv2.PacketStatus_Failure,
-			Acknowledgement: []byte(err.Error()),
+			Acknowledgement: channeltypes.NewErrorAcknowledgement(err).Acknowledgement(),
 		}
 	}
 

--- a/modules/rate-limiting/v2/ibc_middleware_test.go
+++ b/modules/rate-limiting/v2/ibc_middleware_test.go
@@ -1,0 +1,124 @@
+package v2
+
+import (
+	"encoding/json"
+	"testing"
+
+	transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
+	channeltypesv2 "github.com/cosmos/ibc-go/v10/modules/core/04-channel/v2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestV2ToV1Packet_WithJSONEncoding(t *testing.T) {
+	payloadValue := transfertypes.FungibleTokenPacketData{
+		Denom:    "denom",
+		Amount:   "100",
+		Sender:   "sender",
+		Receiver: "receiver",
+		Memo:     "memo",
+	}
+	payloadValueBz, err := transfertypes.MarshalPacketData(payloadValue, transfertypes.V1, transfertypes.EncodingJSON)
+	require.NoError(t, err)
+
+	payload := channeltypesv2.Payload{
+		SourcePort:      "sourcePort",
+		DestinationPort: "destinationPort",
+		Version:         transfertypes.V1,
+		Encoding:        transfertypes.EncodingJSON,
+		Value:           payloadValueBz,
+	}
+
+	v1Packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
+	require.NoError(t, err)
+
+	var v1PacketData transfertypes.FungibleTokenPacketData
+	err = json.Unmarshal(v1Packet.Data, &v1PacketData)
+	require.NoError(t, err)
+	require.Equal(t, payloadValue, v1PacketData)
+}
+
+func TestV2ToV1Packet_WithABIEncoding(t *testing.T) {
+	payloadValue := transfertypes.FungibleTokenPacketData{
+		Denom:    "denom",
+		Amount:   "100",
+		Sender:   "sender",
+		Receiver: "receiver",
+		Memo:     "memo",
+	}
+
+	payloadValueBz, err := transfertypes.MarshalPacketData(payloadValue, transfertypes.V1, transfertypes.EncodingABI)
+	require.NoError(t, err)
+
+	payload := channeltypesv2.Payload{
+		SourcePort:      "sourcePort",
+		DestinationPort: "destinationPort",
+		Version:         transfertypes.V1,
+		Encoding:        transfertypes.EncodingABI,
+		Value:           payloadValueBz,
+	}
+
+	v1Packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
+	require.NoError(t, err)
+
+	var v1PacketData transfertypes.FungibleTokenPacketData
+	err = json.Unmarshal(v1Packet.Data, &v1PacketData)
+	require.NoError(t, err)
+	require.Equal(t, payloadValue, v1PacketData)
+}
+
+func TestV2ToV1Packet_WithProtobufEncoding(t *testing.T) {
+	payloadValue := transfertypes.FungibleTokenPacketData{
+		Denom:    "denom",
+		Amount:   "100",
+		Sender:   "sender",
+		Receiver: "receiver",
+		Memo:     "memo",
+	}
+
+	payloadValueBz, err := transfertypes.MarshalPacketData(payloadValue, transfertypes.V1, transfertypes.EncodingProtobuf)
+	require.NoError(t, err)
+
+	payload := channeltypesv2.Payload{
+		SourcePort:      "sourcePort",
+		DestinationPort: "destinationPort",
+		Version:         transfertypes.V1,
+		Encoding:        transfertypes.EncodingProtobuf,
+		Value:           payloadValueBz,
+	}
+
+	v1Packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
+	require.NoError(t, err)
+
+	var v1PacketData transfertypes.FungibleTokenPacketData
+	err = json.Unmarshal(v1Packet.Data, &v1PacketData)
+	require.NoError(t, err)
+	require.Equal(t, payloadValue, v1PacketData)
+}
+
+func TestV2ToV1Packet_WithNilPayload(t *testing.T) {
+	payload := channeltypesv2.Payload{
+		SourcePort:      "sourcePort",
+		DestinationPort: "destinationPort",
+		Version:         transfertypes.V1,
+		Encoding:        transfertypes.EncodingABI,
+		Value:           nil,
+	}
+
+	packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
+	require.Error(t, err)
+	require.Nil(t, packet.Data)
+}
+
+func TestV2ToV1Packet_WithEmptyPayload(t *testing.T) {
+	payload := channeltypesv2.Payload{
+		SourcePort:      "sourcePort",
+		DestinationPort: "destinationPort",
+		Version:         transfertypes.V1,
+		Encoding:        transfertypes.EncodingABI,
+		Value:           []byte{},
+	}
+
+	packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
+	require.Error(t, err)
+	require.Nil(t, packet.Data)
+}

--- a/modules/rate-limiting/v2/ibc_middleware_test.go
+++ b/modules/rate-limiting/v2/ibc_middleware_test.go
@@ -31,6 +31,11 @@ func TestV2ToV1Packet_WithJSONEncoding(t *testing.T) {
 
 	v1Packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
 	require.NoError(t, err)
+	require.Equal(t, uint64(1), v1Packet.Sequence)
+	require.Equal(t, payload.SourcePort, v1Packet.SourcePort)
+	require.Equal(t, "sourceClient", v1Packet.SourceChannel)
+	require.Equal(t, payload.DestinationPort, v1Packet.DestinationPort)
+	require.Equal(t, "destinationClient", v1Packet.DestinationChannel)
 
 	var v1PacketData transfertypes.FungibleTokenPacketData
 	err = json.Unmarshal(v1Packet.Data, &v1PacketData)
@@ -60,6 +65,11 @@ func TestV2ToV1Packet_WithABIEncoding(t *testing.T) {
 
 	v1Packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
 	require.NoError(t, err)
+	require.Equal(t, uint64(1), v1Packet.Sequence)
+	require.Equal(t, payload.SourcePort, v1Packet.SourcePort)
+	require.Equal(t, "sourceClient", v1Packet.SourceChannel)
+	require.Equal(t, payload.DestinationPort, v1Packet.DestinationPort)
+	require.Equal(t, "destinationClient", v1Packet.DestinationChannel)
 
 	var v1PacketData transfertypes.FungibleTokenPacketData
 	err = json.Unmarshal(v1Packet.Data, &v1PacketData)
@@ -89,6 +99,11 @@ func TestV2ToV1Packet_WithProtobufEncoding(t *testing.T) {
 
 	v1Packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
 	require.NoError(t, err)
+	require.Equal(t, uint64(1), v1Packet.Sequence)
+	require.Equal(t, payload.SourcePort, v1Packet.SourcePort)
+	require.Equal(t, "sourceClient", v1Packet.SourceChannel)
+	require.Equal(t, payload.DestinationPort, v1Packet.DestinationPort)
+	require.Equal(t, "destinationClient", v1Packet.DestinationChannel)
 
 	var v1PacketData transfertypes.FungibleTokenPacketData
 	err = json.Unmarshal(v1Packet.Data, &v1PacketData)
@@ -105,9 +120,8 @@ func TestV2ToV1Packet_WithNilPayload(t *testing.T) {
 		Value:           nil,
 	}
 
-	packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
+	_, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
 	require.Error(t, err)
-	require.Nil(t, packet.Data)
 }
 
 func TestV2ToV1Packet_WithEmptyPayload(t *testing.T) {
@@ -119,7 +133,6 @@ func TestV2ToV1Packet_WithEmptyPayload(t *testing.T) {
 		Value:           []byte{},
 	}
 
-	packet, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
+	_, err := v2ToV1Packet(payload, "sourceClient", "destinationClient", 1)
 	require.Error(t, err)
-	require.Nil(t, packet.Data)
 }

--- a/modules/rate-limiting/v2/ibc_middleware_test.go
+++ b/modules/rate-limiting/v2/ibc_middleware_test.go
@@ -4,9 +4,10 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	transfertypes "github.com/cosmos/ibc-go/v10/modules/apps/transfer/types"
 	channeltypesv2 "github.com/cosmos/ibc-go/v10/modules/core/04-channel/v2/types"
-	"github.com/stretchr/testify/require"
 )
 
 func TestV2ToV1Packet_WithJSONEncoding(t *testing.T) {


### PR DESCRIPTION
Rate limiting expects payloads to always be json marshaled, so it does not currently support ABI or protobuf encoded payloads.
This PR adds support for all encodings to rate limiting v2.