### PR TITLE
Fix Typo in Log Message in upgrade_test.go

### DIFF
--- a/middleware/packet-forward-middleware/e2e/upgrade_test.go
+++ b/middleware/packet-forward-middleware/e2e/upgrade_test.go
@@ -191,7 +191,7 @@ func CosmosChainUpgradeTest(t *testing.T, chainName, upgradeRepo, upgradeDockerT
 		func() {
 			err := r.StopRelayer(ctx, eRep)
 			if err != nil {
-				t.Logf("an error occured while stopping the relayer: %s", err)
+				t.Logf("an error occurred while stopping the relayer: %s", err)
 			}
 		},
 	)


### PR DESCRIPTION


Description:  
This pull request corrects a typo in the log message within the CosmosChainUpgradeTest function, changing "occured" to "occurred" for improved clarity and professionalism. 