### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/middleware/packet-forward-middleware/e2e/storage_leak_test.go
+++ b/middleware/packet-forward-middleware/e2e/storage_leak_test.go
@@ -27,7 +27,7 @@ type PFMExport struct {
 	} `json:"app_state"`
 }
 
-// TestStorageLeak verifies that that the PFM module does not retain any in-flight packets after a timeout occurs
+// TestStorageLeak verifies that the PFM module does not retain any in-flight packets after a timeout occurs
 func TestStorageLeak(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping in short mode")


### PR DESCRIPTION
remove redundant word in comment