### PR TITLE
fix(ibc-hooks) : align BeginBlock/EndBlock with new SDK interfaces

### DIFF
--- a/modules/ibc-hooks/sdkmodule.go
+++ b/modules/ibc-hooks/sdkmodule.go
@@ -1,7 +1,6 @@
 package ibc_hooks
 
 import (
-	"context"
 	"encoding/json"
 
 	"cosmossdk.io/core/appmodule"
@@ -22,11 +21,11 @@ import (
 )
 
 var (
-	_ module.AppModuleBasic     = AppModuleBasic{}
-	_ module.AppModule          = AppModule{}
-	_ appmodule.AppModule       = AppModule{}
-	_ appmodule.HasEndBlocker   = AppModule{}
-	_ appmodule.HasBeginBlocker = AppModule{}
+	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModule      = AppModule{}
+	_ appmodule.AppModule   = AppModule{}
+
+	// This module does not implement any begin or end block logic
 )
 
 // AppModuleBasic defines the basic application module used by the ibc-hooks module.
@@ -109,17 +108,6 @@ func (am AppModule) InitGenesis(ctx sdk.Context, cdc codec.JSONCodec, data json.
 
 func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.RawMessage {
 	return json.RawMessage([]byte("{}"))
-}
-
-// BeginBlock returns the begin blocker for the ibc-hooks module.
-func (am AppModule) BeginBlock(_ context.Context) error {
-	return nil
-}
-
-// EndBlock returns the end blocker for the ibc-hooks module. It returns no validator
-// updates.
-func (AppModule) EndBlock(_ context.Context) error {
-	return nil
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.

--- a/modules/ibc-hooks/sdkmodule.go
+++ b/modules/ibc-hooks/sdkmodule.go
@@ -1,8 +1,10 @@
 package ibc_hooks
 
 import (
+	"context"
 	"encoding/json"
 
+	"cosmossdk.io/core/appmodule"
 	"github.com/cosmos/ibc-apps/modules/ibc-hooks/v10/client/cli"
 	"github.com/cosmos/ibc-apps/modules/ibc-hooks/v10/types"
 	"github.com/gorilla/mux"
@@ -20,8 +22,11 @@ import (
 )
 
 var (
-	_ module.AppModule      = AppModule{}
-	_ module.AppModuleBasic = AppModuleBasic{}
+	_ module.AppModuleBasic     = AppModuleBasic{}
+	_ module.AppModule          = AppModule{}
+	_ appmodule.AppModule       = AppModule{}
+	_ appmodule.HasEndBlocker   = AppModule{}
+	_ appmodule.HasBeginBlocker = AppModule{}
 )
 
 // AppModuleBasic defines the basic application module used by the ibc-hooks module.
@@ -107,13 +112,14 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // BeginBlock returns the begin blocker for the ibc-hooks module.
-func (am AppModule) BeginBlock(ctx sdk.Context) {
+func (am AppModule) BeginBlock(_ context.Context) error {
+	return nil
 }
 
 // EndBlock returns the end blocker for the ibc-hooks module. It returns no validator
 // updates.
-func (AppModule) EndBlock(_ sdk.Context) []abci.ValidatorUpdate {
-	return []abci.ValidatorUpdate{}
+func (AppModule) EndBlock(_ context.Context) error {
+	return nil
 }
 
 // ConsensusVersion implements AppModule/ConsensusVersion.


### PR DESCRIPTION
Previously, ibc-hooks defined BeginBlock/EndBlock in a way that no longer executed under the updated SDK interfaces. While these methods are effectively no-ops for the module, this change updates them to correctly implement the new interfaces for correctness and consistency. They could also be safely removed, but this keeps the implementation aligned with expected behaviour.
