### PR TITLE
fix(rate-limiting): migrate storing channel ids with 64 bytes in store keys instead of 16 bytes

### DIFF
--- a/modules/rate-limiting/keeper/flow.go
+++ b/modules/rate-limiting/keeper/flow.go
@@ -80,11 +80,16 @@ func (k Keeper) UndoSendPacket(ctx sdk.Context, channelOrClientId string, sequen
 
 	// If the packet was sent during this quota, decrement the outflow
 	// Otherwise, it can be ignored
-	if k.CheckPacketSentDuringCurrentQuota(ctx, channelOrClientId, sequence) {
+	found, err := k.CheckPacketSentDuringCurrentQuota(ctx, channelOrClientId, sequence)
+	if err != nil {
+		return err
+	}
+
+	if found {
 		rateLimit.Flow.Outflow = rateLimit.Flow.Outflow.Sub(amount)
 		k.SetRateLimit(ctx, rateLimit)
 
-		k.RemovePendingSendPacket(ctx, channelOrClientId, sequence)
+		return k.RemovePendingSendPacket(ctx, channelOrClientId, sequence)
 	}
 
 	return nil

--- a/modules/rate-limiting/keeper/flow_test.go
+++ b/modules/rate-limiting/keeper/flow_test.go
@@ -408,11 +408,12 @@ func (s *KeeperTestSuite) TestUndoSendPacket() {
 	s.App.RatelimitKeeper.SetRateLimit(s.Ctx, rateLimit2)
 
 	// Store a pending packet sequence number of 2 for the first rate limit
-	s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, channelId, 2)
+	err := s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, channelId, 2)
+	s.Require().NoError(err, "unexpected error setting pending send packet sequence - channel %s, sequence %d", channelId, 2)
 
 	// Undo a send of 10 from the first rate limit, with sequence 1
 	// If should NOT modify the outflow since sequence 1 was not sent in the current quota
-	err := s.App.RatelimitKeeper.UndoSendPacket(s.Ctx, channelId, 1, denom, packetSendAmount)
+	err = s.App.RatelimitKeeper.UndoSendPacket(s.Ctx, channelId, 1, denom, packetSendAmount)
 	s.Require().NoError(err, "no error expected when undoing send packet sequence 1")
 
 	checkOutflow(channelId, denom, initialOutflow)
@@ -428,6 +429,7 @@ func (s *KeeperTestSuite) TestUndoSendPacket() {
 	checkOutflow("different-channel", "different-denom", initialOutflow)
 
 	// Confirm sequence number was removed
-	found := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, 2)
+	found, err := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, 2)
+	s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %d", channelId, 2)
 	s.Require().False(found, "packet sequence number should have been removed")
 }

--- a/modules/rate-limiting/keeper/genesis.go
+++ b/modules/rate-limiting/keeper/genesis.go
@@ -30,7 +30,9 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 		if err != nil {
 			panic(err.Error())
 		}
-		k.SetPendingSendPacket(ctx, channelOrClientId, sequence)
+		if err := k.SetPendingSendPacket(ctx, channelOrClientId, sequence); err != nil {
+			panic(err)
+		}
 	}
 
 	// If the hour epoch has been initialized already (epoch number != 0), validate and then use it
@@ -50,11 +52,16 @@ func (k Keeper) InitGenesis(ctx sdk.Context, genState types.GenesisState) {
 func (k Keeper) ExportGenesis(ctx sdk.Context) *types.GenesisState {
 	genesis := types.DefaultGenesis()
 
+	pendingSendPackets, err := k.GetAllPendingSendPackets(ctx)
+	if err != nil {
+		panic(err)
+	}
+
 	genesis.Params = k.GetParams(ctx)
 	genesis.RateLimits = k.GetAllRateLimits(ctx)
 	genesis.BlacklistedDenoms = k.GetAllBlacklistedDenoms(ctx)
 	genesis.WhitelistedAddressPairs = k.GetAllWhitelistedAddressPairs(ctx)
-	genesis.PendingSendPacketSequenceNumbers = k.GetAllPendingSendPackets(ctx)
+	genesis.PendingSendPacketSequenceNumbers = pendingSendPackets
 	genesis.HourEpoch = k.GetHourEpoch(ctx)
 
 	return genesis

--- a/modules/rate-limiting/keeper/migrator.go
+++ b/modules/rate-limiting/keeper/migrator.go
@@ -1,9 +1,9 @@
 package keeper
 
 import (
-	sdk "github.com/cosmos/cosmos-sdk/types"
-
 	v2 "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/migrations/v2"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 )
 
 // Migrator is a struct for handling in-place store migrations.

--- a/modules/rate-limiting/keeper/migrator.go
+++ b/modules/rate-limiting/keeper/migrator.go
@@ -1,0 +1,23 @@
+package keeper
+
+import (
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	v2 "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/migrations/v2"
+)
+
+// Migrator is a struct for handling in-place store migrations.
+type Migrator struct {
+	keeper Keeper
+}
+
+// NewMigrator creates a new Migrator instance.
+func NewMigrator(k Keeper) Migrator {
+	return Migrator{keeper: k}
+}
+
+// Migrate1to2 widens the PendingSendPacket key's channel-ID segment from
+// 16 to 64 bytes so IBC v2 channel IDs fit.
+func (m Migrator) Migrate1to2(ctx sdk.Context) error {
+	return v2.Migrate(ctx, m.keeper.storeService)
+}

--- a/modules/rate-limiting/keeper/migrator_test.go
+++ b/modules/rate-limiting/keeper/migrator_test.go
@@ -1,0 +1,155 @@
+package keeper_test
+
+import (
+	"encoding/binary"
+
+	"cosmossdk.io/store/prefix"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/ibc-apps/modules/rate-limiting/v10/keeper"
+	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
+)
+
+func (s *KeeperTestSuite) TestMigrate1to2() {
+	const oldPendingSendPacketChannelLength = 16
+	const newPendingSendPacketChannelLength = 64
+	const oldKeyLen = oldPendingSendPacketChannelLength + 8
+	const newKeyLen = newPendingSendPacketChannelLength + 8
+
+	writeLegacy := func(store prefix.Store, channelID string, sequence uint64) {
+		key := make([]byte, oldKeyLen)
+		copy(key, channelID)
+		binary.BigEndian.PutUint64(key[oldPendingSendPacketChannelLength:], sequence)
+		store.Set(key, []byte{1})
+	}
+
+	writeNewLayout := func(store prefix.Store, channelID string, sequence uint64) {
+		key := make([]byte, newKeyLen)
+		copy(key, channelID)
+		binary.BigEndian.PutUint64(key[newPendingSendPacketChannelLength:], sequence)
+		store.Set(key, []byte{1})
+	}
+
+	readAllKeys := func(store prefix.Store) [][]byte {
+		it := store.Iterator(nil, nil)
+		defer it.Close()
+
+		var keys [][]byte
+		for ; it.Valid(); it.Next() {
+			keys = append(keys, append([]byte(nil), it.Key()...))
+		}
+		return keys
+	}
+
+	var (
+		ctx      sdk.Context
+		rlKeeper keeper.Keeper
+		migrator keeper.Migrator
+	)
+
+	tests := []struct {
+		name      string
+		malleate  func(store prefix.Store)
+		expectAll []string
+		expectErr string
+	}{
+		{
+			name:     "success: empty store",
+			malleate: func(_ prefix.Store) {},
+		},
+		{
+			name: "success: legacy entries rewritten",
+			malleate: func(store prefix.Store) {
+				writeLegacy(store, "channel-1", 1)
+				writeLegacy(store, "channel-1", 2)
+				writeLegacy(store, "channel-11", 1)
+				writeLegacy(store, "channel-11", 7)
+				writeLegacy(store, "07-tendermint-10", 500)
+				// note this following channelID will get truncated when written to the store
+				writeLegacy(store, "07-tendermint-5011", 600)
+			},
+			expectAll: []string{
+				"channel-1/1", "channel-1/2",
+				"channel-11/1", "channel-11/7",
+				"07-tendermint-10/500", "07-tendermint-50/600",
+			},
+		},
+		{
+			name: "failure: already migrated entry",
+			malleate: func(store prefix.Store) {
+				writeLegacy(store, "channel-1", 1)
+				writeNewLayout(store, "channel-99", 5)
+			},
+			expectErr: "unexpected pending-send-packet key length",
+		},
+		{
+			name: "failure: unexpected key length",
+			malleate: func(store prefix.Store) {
+				// key length is does not match oldKeyLen
+				store.Set(make([]byte, oldKeyLen+1), []byte{1})
+			},
+			expectErr: "unexpected pending-send-packet key length",
+		},
+		{
+			name: "failure: existing channel ID too short",
+			malleate: func(store prefix.Store) {
+				writeLegacy(store, "abc", 1)
+			},
+			expectErr: "invalid channel or client ID",
+		},
+		{
+			name: "failure: invalid existing channelID",
+			malleate: func(store prefix.Store) {
+				writeLegacy(store, "ch/1", 1)
+			},
+			expectErr: "invalid channel or client ID",
+		},
+		{
+			name: "failure: existing sequence 0",
+			malleate: func(store prefix.Store) {
+				writeLegacy(store, "channel-1", 0)
+			},
+			expectErr: "invalid sequence 0",
+		},
+	}
+
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			s.SetupTest()
+
+			rlKeeper = s.App.RatelimitKeeper
+			migrator = keeper.NewMigrator(rlKeeper)
+
+			storeService := runtime.NewKVStoreService(s.App.GetKey(ratelimittypes.StoreKey))
+			adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(s.Ctx))
+			prefixStore := prefix.NewStore(adapter, ratelimittypes.PendingSendPacketPrefix)
+
+			// set initial store state
+			tc.malleate(prefixStore)
+
+			// perform migration
+			err := migrator.Migrate1to2(ctx)
+
+			if tc.expectErr != "" {
+				s.Require().ErrorContains(err, tc.expectErr)
+				return
+			}
+			s.Require().NoError(err)
+
+			// assert that all keys match our expected keys, or there are no
+			// keys at all
+			for _, k := range readAllKeys(prefixStore) {
+				s.Require().Len(k, newKeyLen, "every post-migration key must be in the new layout")
+			}
+
+			pendingSendPackets, err := rlKeeper.GetAllPendingSendPackets(ctx)
+			s.Require().NoError(err)
+			if tc.expectAll == nil {
+				s.Require().Empty(pendingSendPackets)
+			} else {
+				s.Require().ElementsMatch(tc.expectAll, pendingSendPackets)
+			}
+		})
+	}
+}

--- a/modules/rate-limiting/keeper/migrator_test.go
+++ b/modules/rate-limiting/keeper/migrator_test.go
@@ -3,11 +3,12 @@ package keeper_test
 import (
 	"encoding/binary"
 
-	"cosmossdk.io/store/prefix"
-	"github.com/cosmos/cosmos-sdk/runtime"
-
 	"github.com/cosmos/ibc-apps/modules/rate-limiting/v10/keeper"
 	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
+
+	"cosmossdk.io/store/prefix"
+
+	"github.com/cosmos/cosmos-sdk/runtime"
 )
 
 func (s *KeeperTestSuite) TestMigrate1to2() {

--- a/modules/rate-limiting/keeper/migrator_test.go
+++ b/modules/rate-limiting/keeper/migrator_test.go
@@ -5,7 +5,6 @@ import (
 
 	"cosmossdk.io/store/prefix"
 	"github.com/cosmos/cosmos-sdk/runtime"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"github.com/cosmos/ibc-apps/modules/rate-limiting/v10/keeper"
 	ratelimittypes "github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
@@ -41,12 +40,6 @@ func (s *KeeperTestSuite) TestMigrate1to2() {
 		}
 		return keys
 	}
-
-	var (
-		ctx      sdk.Context
-		rlKeeper keeper.Keeper
-		migrator keeper.Migrator
-	)
 
 	tests := []struct {
 		name      string
@@ -118,9 +111,6 @@ func (s *KeeperTestSuite) TestMigrate1to2() {
 		s.Run(tc.name, func() {
 			s.SetupTest()
 
-			rlKeeper = s.App.RatelimitKeeper
-			migrator = keeper.NewMigrator(rlKeeper)
-
 			storeService := runtime.NewKVStoreService(s.App.GetKey(ratelimittypes.StoreKey))
 			adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(s.Ctx))
 			prefixStore := prefix.NewStore(adapter, ratelimittypes.PendingSendPacketPrefix)
@@ -129,7 +119,7 @@ func (s *KeeperTestSuite) TestMigrate1to2() {
 			tc.malleate(prefixStore)
 
 			// perform migration
-			err := migrator.Migrate1to2(ctx)
+			err := keeper.NewMigrator(s.App.RatelimitKeeper).Migrate1to2(s.Ctx)
 
 			if tc.expectErr != "" {
 				s.Require().ErrorContains(err, tc.expectErr)
@@ -143,7 +133,7 @@ func (s *KeeperTestSuite) TestMigrate1to2() {
 				s.Require().Len(k, newKeyLen, "every post-migration key must be in the new layout")
 			}
 
-			pendingSendPackets, err := rlKeeper.GetAllPendingSendPackets(ctx)
+			pendingSendPackets, err := s.App.RatelimitKeeper.GetAllPendingSendPackets(s.Ctx)
 			s.Require().NoError(err)
 			if tc.expectAll == nil {
 				s.Require().Empty(pendingSendPackets)

--- a/modules/rate-limiting/keeper/packet.go
+++ b/modules/rate-limiting/keeper/packet.go
@@ -206,7 +206,7 @@ func (k Keeper) SendRateLimitedPacket(ctx sdk.Context, packet channeltypes.Packe
 	// Store the sequence number of the packet so that if the transfer fails,
 	// we can identify if it was sent during this quota and can revert the outflow
 	if updatedFlow {
-		k.SetPendingSendPacket(ctx, packetInfo.ChannelID, packet.Sequence)
+		return k.SetPendingSendPacket(ctx, packetInfo.ChannelID, packet.Sequence)
 	}
 
 	return nil
@@ -241,8 +241,7 @@ func (k Keeper) AcknowledgeRateLimitedPacket(ctx sdk.Context, packet channeltype
 
 	// If the ack was successful, remove the pending packet
 	if ackSuccess {
-		k.RemovePendingSendPacket(ctx, packetInfo.ChannelID, packet.Sequence)
-		return nil
+		return k.RemovePendingSendPacket(ctx, packetInfo.ChannelID, packet.Sequence)
 	}
 
 	// If the ack failed, undo the change to the rate limit Outflow

--- a/modules/rate-limiting/keeper/packet_test.go
+++ b/modules/rate-limiting/keeper/packet_test.go
@@ -270,7 +270,8 @@ func (s *KeeperTestSuite) TestSendRateLimitedPacket() {
 	s.Require().NoError(err, "no error expected when sending packet after reset")
 
 	// Check that the pending packet was stored
-	found := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	found, err := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %d", sourceChannel, sequence)
 	s.Require().True(found, "pending send packet")
 }
 
@@ -319,7 +320,8 @@ func (s *KeeperTestSuite) TestAcknowledgeRateLimitedPacket_AckSuccess() {
 	})
 
 	// Store the pending packet for this sequence number
-	s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	err := s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error setting pending send packet sequence - channel %s, sequence %d", sourceChannel, sequence)
 
 	// Build the ack packet
 	packetData, err := json.Marshal(transfertypes.FungibleTokenPacketData{Denom: denom, Amount: "10"})
@@ -341,7 +343,8 @@ func (s *KeeperTestSuite) TestAcknowledgeRateLimitedPacket_AckSuccess() {
 	s.Require().NoError(err, "no error expected during AckPacket")
 
 	// Confirm the pending packet was removed
-	found := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	found, err := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %d", sourceChannel, sequence)
 	s.Require().False(found, "send packet should have been removed")
 }
 
@@ -361,7 +364,8 @@ func (s *KeeperTestSuite) TestAcknowledgeRateLimitedPacket_AckFailure() {
 	})
 
 	// Store the pending packet for this sequence number
-	s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	err := s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error setting pending send packet sequence - channel %s, sequence %d", sourceChannel, sequence)
 
 	// Build the ack packet
 	packetData, err := json.Marshal(transfertypes.FungibleTokenPacketData{Denom: denom, Amount: packetAmount.String()})
@@ -383,7 +387,8 @@ func (s *KeeperTestSuite) TestAcknowledgeRateLimitedPacket_AckFailure() {
 	s.Require().NoError(err, "no error expected during AckPacket")
 
 	// Confirm the pending packet was removed
-	found := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	found, err := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %d", sourceChannel, sequence)
 	s.Require().False(found, "send packet should have been removed")
 
 	// Confirm the flow was adjusted
@@ -408,7 +413,8 @@ func (s *KeeperTestSuite) TestAcknowledgeRateLimitedPacket_UniversalErrorAck() {
 	})
 
 	// Store the pending packet for this sequence number
-	s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	err := s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error setting pending send packet sequence - channel %s, sequence %d", sourceChannel, sequence)
 
 	// Build the ack packet
 	packetData, err := json.Marshal(transfertypes.FungibleTokenPacketData{Denom: denom, Amount: packetAmount.String()})
@@ -428,7 +434,8 @@ func (s *KeeperTestSuite) TestAcknowledgeRateLimitedPacket_UniversalErrorAck() {
 	s.Require().NoError(err, "no error expected during AckPacket")
 
 	// Confirm the pending packet was removed
-	found := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	found, err := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %d", sourceChannel, sequence)
 	s.Require().False(found, "send packet should have been removed")
 
 	// Confirm the flow was adjusted
@@ -477,7 +484,8 @@ func (s *KeeperTestSuite) TestTimeoutRateLimitedPacket() {
 	s.Require().Equal(expectedOutflow.Int64(), rateLimit.Flow.Outflow.Int64(), "outflow decremented")
 
 	// Check that the pending packet has been removed
-	found = s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, sequence)
+	found, err = s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, sequence)
+	s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %d", channelId, sequence)
 	s.Require().False(found, "pending packet should have been removed")
 
 	// Call OnTimeoutPacket again with a different sequence number

--- a/modules/rate-limiting/keeper/packet_test.go
+++ b/modules/rate-limiting/keeper/packet_test.go
@@ -460,7 +460,8 @@ func (s *KeeperTestSuite) TestTimeoutRateLimitedPacket() {
 	})
 
 	// Store the pending packet for this sequence number
-	s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	err := s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, sourceChannel, sequence)
+	s.Require().NoError(err, "unexpected error setting packet send - channel %s, sequence %d", sourceChannel, sequence)
 
 	// Build the timeout packet
 	packetData, err := json.Marshal(transfertypes.FungibleTokenPacketData{Denom: denom, Amount: packetAmount.String()})

--- a/modules/rate-limiting/keeper/pending_send.go
+++ b/modules/rate-limiting/keeper/pending_send.go
@@ -63,7 +63,7 @@ func (k Keeper) GetAllPendingSendPackets(ctx sdk.Context) (pendingPackets []stri
 
 	iterator := store.Iterator(nil, nil)
 	defer func() {
-		err = errors.Join(err, iterator.Close())
+		err = iterator.Close()
 	}()
 
 	pendingPackets = make([]string, 0)
@@ -96,7 +96,7 @@ func (k Keeper) RemoveAllChannelPendingSendPackets(ctx sdk.Context, channelId st
 
 	iterator := storetypes.KVStorePrefixIterator(store, channelIDBz)
 	defer func() {
-		err = errors.Join(iterator.Close())
+		err = errors.Join(err, iterator.Close())
 	}()
 
 	for ; iterator.Valid(); iterator.Next() {

--- a/modules/rate-limiting/keeper/pending_send.go
+++ b/modules/rate-limiting/keeper/pending_send.go
@@ -2,11 +2,13 @@ package keeper
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
 
+	errorsmod "cosmossdk.io/errors"
 	"cosmossdk.io/store/prefix"
 	storetypes "cosmossdk.io/store/types"
 
@@ -15,42 +17,56 @@ import (
 )
 
 // Sets the sequence number of a packet that was just sent
-func (k Keeper) SetPendingSendPacket(ctx sdk.Context, channelId string, sequence uint64) {
+func (k Keeper) SetPendingSendPacket(ctx sdk.Context, channelId string, sequence uint64) error {
 	adapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
-	key := types.GetPendingSendPacketKey(channelId, sequence)
+	key, err := types.GetPendingSendPacketKey(channelId, sequence)
+	if err != nil {
+		return err
+	}
 	store.Set(key, []byte{1})
+	return nil
 }
 
 // Remove a pending packet sequence number from the store
 // Used after the ack or timeout for a packet has been received
-func (k Keeper) RemovePendingSendPacket(ctx sdk.Context, channelId string, sequence uint64) {
+func (k Keeper) RemovePendingSendPacket(ctx sdk.Context, channelId string, sequence uint64) error {
 	adapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
-	key := types.GetPendingSendPacketKey(channelId, sequence)
+	key, err := types.GetPendingSendPacketKey(channelId, sequence)
+	if err != nil {
+		return err
+	}
+
 	store.Delete(key)
+	return nil
 }
 
 // Checks whether the packet sequence number is in the store - indicating that it was
 // sent during the current quota
-func (k Keeper) CheckPacketSentDuringCurrentQuota(ctx sdk.Context, channelId string, sequence uint64) bool {
+func (k Keeper) CheckPacketSentDuringCurrentQuota(ctx sdk.Context, channelId string, sequence uint64) (bool, error) {
 	adapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
-	key := types.GetPendingSendPacketKey(channelId, sequence)
+	key, err := types.GetPendingSendPacketKey(channelId, sequence)
+	if err != nil {
+		return false, err
+	}
 	valueBz := store.Get(key)
 	found := len(valueBz) != 0
-	return found
+	return found, nil
 }
 
 // Get all pending packet sequence numbers
-func (k Keeper) GetAllPendingSendPackets(ctx sdk.Context) []string {
+func (k Keeper) GetAllPendingSendPackets(ctx sdk.Context) (pendingPackets []string, err error) {
 	adapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
 
 	iterator := store.Iterator(nil, nil)
-	defer iterator.Close()
+	defer func() {
+		err = errors.Join(err, iterator.Close())
+	}()
 
-	pendingPackets := []string{}
+	pendingPackets = make([]string, 0)
 	for ; iterator.Valid(); iterator.Next() {
 		key := iterator.Key()
 
@@ -62,19 +78,29 @@ func (k Keeper) GetAllPendingSendPackets(ctx sdk.Context) []string {
 		pendingPackets = append(pendingPackets, packetId)
 	}
 
-	return pendingPackets
+	return pendingPackets, nil
 }
 
 // Remove all pending sequence numbers from the store
 // This is executed when the quota resets
-func (k Keeper) RemoveAllChannelPendingSendPackets(ctx sdk.Context, channelId string) {
+func (k Keeper) RemoveAllChannelPendingSendPackets(ctx sdk.Context, channelId string) (err error) {
 	adapter := runtime.KVStoreAdapter(k.storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
 
-	iterator := storetypes.KVStorePrefixIterator(store, types.KeyPrefix(channelId))
-	defer iterator.Close()
+	if len(channelId) > types.PendingSendPacketChannelLength {
+		return errorsmod.Wrapf(types.ErrInvalidChannelId, "channel %s with length %d is greater than the allowed length %d", channelId, len(channelId), types.PendingSendPacketChannelLength)
+	}
+
+	channelIDBz := make([]byte, types.PendingSendPacketChannelLength)
+	copy(channelIDBz, channelId)
+
+	iterator := storetypes.KVStorePrefixIterator(store, channelIDBz)
+	defer func() {
+		err = errors.Join(iterator.Close())
+	}()
 
 	for ; iterator.Valid(); iterator.Next() {
 		store.Delete(iterator.Key())
 	}
+	return nil
 }

--- a/modules/rate-limiting/keeper/pending_send_test.go
+++ b/modules/rate-limiting/keeper/pending_send_test.go
@@ -3,38 +3,50 @@ package keeper_test
 import "fmt"
 
 func (s *KeeperTestSuite) TestPendingSendPacketPrefix() {
-	// Store 5 packets across two channels
+	// Store 5 packets across 4 channels
+	channels := []string{"07-tendermint-1000", "07-tendermint-1005", "channel-1", "channel-11"}
 	sendPackets := []string{}
-	for _, channelId := range []string{"channel-0", "channel-1"} {
+	for _, channelId := range channels {
 		for sequence := uint64(0); sequence < 5; sequence++ {
-			s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, channelId, sequence)
+			err := s.App.RatelimitKeeper.SetPendingSendPacket(s.Ctx, channelId, sequence)
+			s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %s", channelId, sequence)
 			sendPackets = append(sendPackets, fmt.Sprintf("%s/%d", channelId, sequence))
 		}
 	}
 
 	// Check that they each sequence number is found
-	for _, channelId := range []string{"channel-0", "channel-1"} {
+	for _, channelId := range channels {
 		for sequence := uint64(0); sequence < 5; sequence++ {
-			found := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, sequence)
+			found, err := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, sequence)
+			s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %s", channelId, sequence)
 			s.Require().True(found, "send packet should have been found - channel %s, sequence: %d", channelId, sequence)
 		}
 	}
 
 	// Check lookup of all sequence numbers
-	actualSendPackets := s.App.RatelimitKeeper.GetAllPendingSendPackets(s.Ctx)
+	actualSendPackets, err := s.App.RatelimitKeeper.GetAllPendingSendPackets(s.Ctx)
+	s.Require().NoError(err, "unexpected error getting pending send packets")
 	s.Require().Equal(sendPackets, actualSendPackets, "all send packets")
 
-	// Remove 0 sequence numbers and all sequence numbers from channel-0
-	s.App.RatelimitKeeper.RemovePendingSendPacket(s.Ctx, "channel-0", 0)
-	s.App.RatelimitKeeper.RemovePendingSendPacket(s.Ctx, "channel-1", 0)
-	s.App.RatelimitKeeper.RemoveAllChannelPendingSendPackets(s.Ctx, "channel-0")
+	// Remove 0 sequence numbers and all sequence numbers from channel-0 + 07-tendermint-1005
+	for _, channelId := range channels {
+		s.App.RatelimitKeeper.RemovePendingSendPacket(s.Ctx, channelId, 0)
+	}
+	err = s.App.RatelimitKeeper.RemoveAllChannelPendingSendPackets(s.Ctx, "channel-1")
+	s.Require().NoError(err, "unexpected error removing all pending send packets - channel %s", "channel-1")
+	err = s.App.RatelimitKeeper.RemoveAllChannelPendingSendPackets(s.Ctx, "07-tendermint-1005")
+	s.Require().NoError(err, "unexpected error removing all pending send packets - channel %s", "07-tendermint-1005")
 
 	// Check that only the remaining sequences are found
-	for _, channelId := range []string{"channel-0", "channel-1"} {
+	for _, channelId := range channels {
 		for sequence := uint64(0); sequence < 5; sequence++ {
-			expected := (channelId == "channel-1") && (sequence != 0)
-			actual := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, sequence)
-			s.Require().Equal(expected, actual, "send packet after removal - channel: %s, sequence: %d", channelId, sequence)
+			removed := (channelId == "channel-1") || (channelId == "07-tendermint-1005") || (sequence == 0)
+			actual, err := s.App.RatelimitKeeper.CheckPacketSentDuringCurrentQuota(s.Ctx, channelId, sequence)
+			s.Require().NoError(err, "unexpected error checking packet sent during current quota - channel %s, sequence %s", channelId, sequence)
+
+			// Assert that if we did not remove the packet, then we
+			// successfully find it when checking the quota
+			s.Require().Equal(!removed, actual, "send packet after removal - channel: %s, sequence: %d", channelId, sequence)
 		}
 	}
 }

--- a/modules/rate-limiting/keeper/pending_send_test.go
+++ b/modules/rate-limiting/keeper/pending_send_test.go
@@ -30,7 +30,8 @@ func (s *KeeperTestSuite) TestPendingSendPacketPrefix() {
 
 	// Remove 0 sequence numbers and all sequence numbers from channel-0 + 07-tendermint-1005
 	for _, channelId := range channels {
-		s.App.RatelimitKeeper.RemovePendingSendPacket(s.Ctx, channelId, 0)
+		err := s.App.RatelimitKeeper.RemovePendingSendPacket(s.Ctx, channelId, 0)
+		s.Require().NoError(err, "unexpected error removing sequence 0 pending send packet - channel %s", channelId)
 	}
 	err = s.App.RatelimitKeeper.RemoveAllChannelPendingSendPackets(s.Ctx, "channel-1")
 	s.Require().NoError(err, "unexpected error removing all pending send packets - channel %s", "channel-1")

--- a/modules/rate-limiting/keeper/rate_limit.go
+++ b/modules/rate-limiting/keeper/rate_limit.go
@@ -167,6 +167,5 @@ func (k Keeper) ResetRateLimit(ctx sdk.Context, denom string, channelId string) 
 	rateLimit.Flow = &flow
 
 	k.SetRateLimit(ctx, rateLimit)
-	k.RemoveAllChannelPendingSendPackets(ctx, channelId)
-	return nil
+	return k.RemoveAllChannelPendingSendPackets(ctx, channelId)
 }

--- a/modules/rate-limiting/migrations/v2/migrate.go
+++ b/modules/rate-limiting/migrations/v2/migrate.go
@@ -35,8 +35,7 @@ const (
 
 // Migrate rewrites entries under types.PendingSendPacketPrefix from the old
 // [16-byte channelID][8-byte sequence] layout to the new [64-byte channelID]
-// [8-byte sequence] layout so IBC v2 channel IDs (up to 64 bytes) fit. Entries
-// already in the new layout are skipped, making the migration idempotent.
+// [8-byte sequence] layout so IBC v2 channel IDs (up to 64 bytes) fit.
 func Migrate(ctx sdk.Context, storeService corestore.KVStoreService) error {
 	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
 	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
@@ -79,12 +78,7 @@ type entry struct {
 
 // collectLegacyEntries returns a list of entries in the prefix store that must
 // be migrated from the oldKeyLen to the newKeyLen.
-func collectLegacyEntries(store prefix.Store) ([]entry, error) {
-	var (
-		legacy []entry
-		err    error
-	)
-
+func collectLegacyEntries(store prefix.Store) (legacy []entry, err error) {
 	iterator := store.Iterator(nil, nil)
 	defer func() {
 		err = errors.Join(err, iterator.Close())

--- a/modules/rate-limiting/migrations/v2/migrate.go
+++ b/modules/rate-limiting/migrations/v2/migrate.go
@@ -8,13 +8,14 @@ import (
 	"slices"
 	"strings"
 
-	corestore "cosmossdk.io/core/store"
+	"github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
 
+	corestore "cosmossdk.io/core/store"
 	"cosmossdk.io/store/prefix"
+
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
 	host "github.com/cosmos/ibc-go/v10/modules/core/24-host"
 )
 

--- a/modules/rate-limiting/migrations/v2/migrate.go
+++ b/modules/rate-limiting/migrations/v2/migrate.go
@@ -1,0 +1,150 @@
+package v2
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	corestore "cosmossdk.io/core/store"
+
+	"cosmossdk.io/store/prefix"
+	"github.com/cosmos/cosmos-sdk/runtime"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/cosmos/ibc-apps/modules/rate-limiting/v10/types"
+	host "github.com/cosmos/ibc-go/v10/modules/core/24-host"
+)
+
+const (
+	// oldPendingSendPacketChannelLength is hard-coded so the migration stays
+	// correct even if types.PendingSendPacketChannelLength is bumped again
+	// later.
+	oldPendingSendPacketChannelLength = 16
+	oldKeyLen                         = oldPendingSendPacketChannelLength + 8
+
+	// newPendingSendPacketChannelLength is hard-coded so the migration stays
+	// correct even if types.PendingSendPacketChannelLength is bumped again
+	// later.
+	newPendingSendPacketChannelLength = 64
+	newKeyLen                         = newPendingSendPacketChannelLength + 8
+)
+
+// Migrate rewrites entries under types.PendingSendPacketPrefix from the old
+// [16-byte channelID][8-byte sequence] layout to the new [64-byte channelID]
+// [8-byte sequence] layout so IBC v2 channel IDs (up to 64 bytes) fit. Entries
+// already in the new layout are skipped, making the migration idempotent.
+func Migrate(ctx sdk.Context, storeService corestore.KVStoreService) error {
+	adapter := runtime.KVStoreAdapter(storeService.OpenKVStore(ctx))
+	store := prefix.NewStore(adapter, types.PendingSendPacketPrefix)
+
+	// get store entries that need to be migrated
+	legacyEntries, err := collectLegacyEntries(store)
+	if err != nil {
+		return fmt.Errorf("collecting legacy pending send packet entries from prefix store: %w", err)
+	}
+
+	// migrate store entries
+	// old key layout: [16-byte channelID][8-byte sequence]
+	// new key layout: [64-byte channelID][8-byte sequence]
+	for _, entry := range legacyEntries {
+		newKey := make([]byte, newKeyLen)
+
+		// place 16 byte channel id from old key into first 64 bytes of new key
+		copy(newKey, entry.key[:oldPendingSendPacketChannelLength])
+
+		// put remaining 8 bytes sequence from old key into the final 8 bytes
+		// sequence of the new key
+		copy(newKey[newPendingSendPacketChannelLength:], entry.key[oldPendingSendPacketChannelLength:])
+
+		if err := validateMigratedKey(newKey, entry.key); err != nil {
+			return fmt.Errorf("validating migrated key %X against legacy key %X: %w", newKey, entry.key, err)
+		}
+
+		// remove old kv and set new kv
+		store.Delete(entry.key[:])
+		store.Set(newKey, entry.value)
+	}
+
+	return nil
+}
+
+type entry struct {
+	key   [oldKeyLen]byte
+	value []byte
+}
+
+// collectLegacyEntries returns a list of entries in the prefix store that must
+// be migrated from the oldKeyLen to the newKeyLen.
+func collectLegacyEntries(store prefix.Store) ([]entry, error) {
+	var (
+		legacy []entry
+		err    error
+	)
+
+	iterator := store.Iterator(nil, nil)
+	defer func() {
+		err = errors.Join(err, iterator.Close())
+	}()
+
+	for ; iterator.Valid(); iterator.Next() {
+		key := iterator.Key()
+		switch len(key) {
+		case oldKeyLen:
+			legacy = append(legacy, entry{
+				key:   [oldKeyLen]byte(key),
+				value: slices.Clone(iterator.Value()),
+			})
+		default:
+			err = fmt.Errorf("unexpected pending-send-packet key length %d (want %d)", len(key), oldKeyLen)
+			return nil, err
+		}
+	}
+
+	return legacy, nil
+}
+
+// validateMigratedKey ensures a legacy key transformation is valid, returns an
+// error if not.
+func validateMigratedKey(newKey []byte, oldKey [oldKeyLen]byte) error {
+	// channelID is right-padded with null bytes in the key (see
+	// types.PendingSendPacketKey), so trim them before validating.
+	rawChannelID := string(newKey[:newPendingSendPacketChannelLength])
+	channelID := strings.TrimRight(rawChannelID, "\x00")
+
+	// validate channelID in the newKey.
+
+	// we are using the client
+	// validator here since in v1 these will be channelID's, and in v2 they
+	// are clientID's, the client validator is slightly less strict and
+	// will accept both.
+	if err := host.ClientIdentifierValidator(channelID); err != nil {
+		return fmt.Errorf("invalid channel or client ID %q in migrated key: %w", channelID, err)
+	}
+
+	// ensure we have not modified the existing value
+	if !bytes.Equal(newKey[:oldPendingSendPacketChannelLength], oldKey[:oldPendingSendPacketChannelLength]) {
+		return fmt.Errorf("first %d bytes of migrated key not do not match existing key", oldPendingSendPacketChannelLength)
+	}
+	// ensure after the oldPendingSendPacketChannelLength, we have 48 bytes of 0's
+	padding := newKey[oldPendingSendPacketChannelLength:newPendingSendPacketChannelLength]
+	if !bytes.Equal(padding, make([]byte, len(padding))) {
+		return fmt.Errorf("expected all zero values after channel identifier in migrated key")
+	}
+
+	// validate sequence number in the newKey.
+	sequenceRaw := newKey[newPendingSendPacketChannelLength:]
+	sequence := binary.BigEndian.Uint64(sequenceRaw)
+	if sequence == 0 {
+		return fmt.Errorf("invalid sequence 0 for %q in migrated key", channelID)
+	}
+
+	// ensure we have not modified the existing value
+	if !bytes.Equal(sequenceRaw, oldKey[oldPendingSendPacketChannelLength:]) {
+		return fmt.Errorf("mismatch in sequence number bytes between migrated key and existing key")
+	}
+
+	return nil
+}

--- a/modules/rate-limiting/module.go
+++ b/modules/rate-limiting/module.go
@@ -125,6 +125,11 @@ func (AppModule) QuerierRoute() string { return types.QuerierRoute }
 func (am AppModule) RegisterServices(cfg module.Configurator) {
 	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(am.keeper))
+
+	m := keeper.NewMigrator(am.keeper)
+	if err := cfg.RegisterMigration(types.ModuleName, 1, m.Migrate1to2); err != nil {
+		panic(fmt.Sprintf("failed to migrate x/%s from version 1 to 2: %v", types.ModuleName, err))
+	}
 }
 
 // RegisterInvariants registers the capability module's invariants.
@@ -149,7 +154,7 @@ func (am AppModule) ExportGenesis(ctx sdk.Context, cdc codec.JSONCodec) json.Raw
 }
 
 // ConsensusVersion implements ConsensusVersion.
-func (AppModule) ConsensusVersion() uint64 { return 1 }
+func (AppModule) ConsensusVersion() uint64 { return 2 }
 
 // BeginBlock executes all ABCI BeginBlock logic respective to the capability module.
 func (am AppModule) BeginBlock(ctx context.Context) error {

--- a/modules/rate-limiting/types/errors.go
+++ b/modules/rate-limiting/types/errors.go
@@ -21,4 +21,7 @@ var (
 	ErrDenomIsBlacklisted = errorsmod.Register(ModuleName, 7,
 		"denom is blacklisted",
 	)
+	ErrInvalidChannelId = errorsmod.Register(ModuleName, 8,
+		"invalid channel",
+	)
 )

--- a/modules/rate-limiting/types/keys.go
+++ b/modules/rate-limiting/types/keys.go
@@ -1,6 +1,10 @@
 package types
 
-import "encoding/binary"
+import (
+	"encoding/binary"
+
+	errorsmod "cosmossdk.io/errors"
+)
 
 const (
 	ModuleName = "ratelimit"
@@ -27,7 +31,7 @@ var (
 	AddressWhitelistKeyPrefix = KeyPrefix("address-blacklist")
 	HourEpochKey              = KeyPrefix("hour-epoch")
 
-	PendingSendPacketChannelLength int = 16
+	PendingSendPacketChannelLength int = 64
 )
 
 // Get the rate limit byte key built from the denom and channelId
@@ -38,14 +42,17 @@ func GetRateLimitItemKey(denom string, channelId string) []byte {
 // Get the pending send packet key from the channel ID and sequence number
 // The channel ID must be fixed length to allow for extracting the underlying
 // values from a key
-func GetPendingSendPacketKey(channelId string, sequenceNumber uint64) []byte {
+func GetPendingSendPacketKey(channelId string, sequenceNumber uint64) ([]byte, error) {
+	if len(channelId) > PendingSendPacketChannelLength {
+		return nil, errorsmod.Wrapf(ErrInvalidChannelId, "channel %s with length %d is greater than the allowed length %d", channelId, len(channelId), PendingSendPacketChannelLength)
+	}
 	channelIdBz := make([]byte, PendingSendPacketChannelLength)
 	copy(channelIdBz, channelId)
 
 	sequenceNumberBz := make([]byte, 8)
 	binary.BigEndian.PutUint64(sequenceNumberBz, sequenceNumber)
 
-	return append(channelIdBz, sequenceNumberBz...)
+	return append(channelIdBz, sequenceNumberBz...), nil
 }
 
 // Get the whitelist path key from a sender and receiver address


### PR DESCRIPTION
Updates the max channel id store key bytes in the rate limiting module from 16 bytes to 64 bytes